### PR TITLE
[FEAT] 회원가입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,9 @@ dependencies {
 
     // Micrometer Prometheus
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 dependencyManagement {
     imports {

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/constants/EmailVerificationConstant.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/constants/EmailVerificationConstant.java
@@ -1,0 +1,16 @@
+package laughcandidate.yellowribbonbe.auth.constants;
+
+public class EmailVerificationConstant {
+
+	public static final int VERIFICATION_TIME = 10;
+	public static final String VERIFICATION_CODE_PATTERN = "\\b(\\d{6})\\b";
+	public static final String PREFIX_VERIFICATION_CODE = "code_";
+	public static final String PREFIX_VERIFICATION_TIME = "time_";
+	public static final String IMAP_PROTOCOL = "imaps";
+	public static final String INBOX = "INBOX";
+	public static final String AT = "@";
+	public static final String TEXT = "text/plain";
+	public static final String MULTIPART = "multipart/*";
+	public static final String TXT = ".txt";
+	public static final String VERIFIED = "verified";
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/controller/AuthController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/controller/AuthController.java
@@ -44,4 +44,14 @@ public class AuthController {
 
 		return ResponseEntity.ok(ApiResponse.created(phoneVerificationResultResponse));
 	}
+
+	@PostMapping("/verify-code")
+	@Operation(
+		summary = "인증번호 검증 API",
+		description = "인증번호 검증")
+	public ResponseEntity<ApiResponse<Void>> verify(@RequestBody @Valid PhoneVerificationRequest phoneVerificationRequest) {
+		authService.verifyCode(phoneVerificationRequest.phone());
+
+		return ResponseEntity.ok(ApiResponse.noContent());
+	}
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/controller/AuthController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/controller/AuthController.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import laughcandidate.yellowribbonbe.auth.dto.request.PhoneCheckRequest;
+import laughcandidate.yellowribbonbe.auth.dto.request.PhoneVerificationRequest;
+import laughcandidate.yellowribbonbe.auth.dto.response.PhoneVerificationResultResponse;
 import laughcandidate.yellowribbonbe.auth.service.AuthService;
 import laughcandidate.yellowribbonbe.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -30,5 +32,16 @@ public class AuthController {
 		authService.checkPhoneDuplicate(phoneCheckRequest.phone());
 
 		return ResponseEntity.ok(ApiResponse.noContent());
+	}
+
+	@PostMapping("/send-code")
+	@Operation(
+		summary = "인증번호 요청 API",
+		description = "인증번호 요청")
+	public ResponseEntity<ApiResponse<PhoneVerificationResultResponse>> sendVerificationCode(@RequestBody @Valid PhoneVerificationRequest phoneVerificationRequest) {
+		PhoneVerificationResultResponse phoneVerificationResultResponse = authService.sendVerificationCode(
+			phoneVerificationRequest.phone());
+
+		return ResponseEntity.ok(ApiResponse.created(phoneVerificationResultResponse));
 	}
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/controller/AuthController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/controller/AuthController.java
@@ -11,7 +11,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import laughcandidate.yellowribbonbe.auth.dto.request.PhoneCheckRequest;
 import laughcandidate.yellowribbonbe.auth.dto.request.PhoneVerificationRequest;
+import laughcandidate.yellowribbonbe.auth.dto.request.RegisterRequest;
 import laughcandidate.yellowribbonbe.auth.dto.response.PhoneVerificationResultResponse;
+import laughcandidate.yellowribbonbe.auth.dto.response.RegisterResponse;
 import laughcandidate.yellowribbonbe.auth.service.AuthService;
 import laughcandidate.yellowribbonbe.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -53,5 +55,16 @@ public class AuthController {
 		authService.verifyCode(phoneVerificationRequest.phone());
 
 		return ResponseEntity.ok(ApiResponse.noContent());
+	}
+
+	@PostMapping("/register")
+	@Operation(
+		summary = "회원가입 API",
+		description = "회원가입")
+	public ResponseEntity<ApiResponse<RegisterResponse>> register(@RequestBody @Valid RegisterRequest registerRequest) {
+		RegisterResponse register = authService.register(registerRequest.name(), registerRequest.phone(),
+			registerRequest.password());
+
+		return ResponseEntity.ok(ApiResponse.ok(register));
 	}
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/controller/AuthController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/controller/AuthController.java
@@ -1,0 +1,34 @@
+package laughcandidate.yellowribbonbe.auth.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import laughcandidate.yellowribbonbe.auth.dto.request.PhoneCheckRequest;
+import laughcandidate.yellowribbonbe.auth.service.AuthService;
+import laughcandidate.yellowribbonbe.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "인증/인가")
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	@PostMapping("/check-phone")
+	@Operation(
+		summary = "전화번호 중복 확인 API",
+		description = "전화번호 중복 확인")
+	public ResponseEntity<ApiResponse<Void>> checkIdDuplicate(@RequestBody @Valid PhoneCheckRequest phoneCheckRequest) {
+		authService.checkPhoneDuplicate(phoneCheckRequest.phone());
+
+		return ResponseEntity.ok(ApiResponse.noContent());
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/dto/ImapCredentials.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/dto/ImapCredentials.java
@@ -1,0 +1,4 @@
+package laughcandidate.yellowribbonbe.auth.dto;
+
+public record ImapCredentials(String userName, String password) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/dto/request/LoginRequest.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package laughcandidate.yellowribbonbe.auth.dto;
+package laughcandidate.yellowribbonbe.auth.dto.request;
 
 public record LoginRequest(
     String id,

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/dto/request/PhoneCheckRequest.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/dto/request/PhoneCheckRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
-@Schema(name = "LoginRequest: 로그인 요청 Dto")
+@Schema(name = "PhoneCheckRequest: 전화번호 중복 검증 Dto")
 public record PhoneCheckRequest(
 	@NotBlank(message = "휴대전화 번호는 필수 입력값입니다.")
 	@Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하는 11자리 숫자여야 합니다.")

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/dto/request/PhoneCheckRequest.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/dto/request/PhoneCheckRequest.java
@@ -1,0 +1,14 @@
+package laughcandidate.yellowribbonbe.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(name = "LoginRequest: 로그인 요청 Dto")
+public record PhoneCheckRequest(
+	@NotBlank(message = "휴대전화 번호는 필수 입력값입니다.")
+	@Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하는 11자리 숫자여야 합니다.")
+	@Schema(description = "휴대전화 번호", example = "01012341234")
+	String phone
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/dto/request/PhoneVerificationRequest.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/dto/request/PhoneVerificationRequest.java
@@ -1,0 +1,14 @@
+package laughcandidate.yellowribbonbe.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(name = "PhoneVerificationRequest: 전화번호 인증번호 요청 Dto")
+public record PhoneVerificationRequest(
+	@NotBlank(message = "휴대전화 번호는 필수 입력값입니다.")
+	@Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하는 11자리 숫자여야 합니다.")
+	@Schema(description = "휴대전화 번호", example = "01012341234")
+	String phone
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/dto/request/RegisterRequest.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/dto/request/RegisterRequest.java
@@ -1,0 +1,30 @@
+package laughcandidate.yellowribbonbe.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(name = "RegisterRequest: 회원가입 요청 Dto")
+public record RegisterRequest(
+	@NotBlank
+	@Schema(description = "이름", example = "김돌돌")
+	String name,
+
+	@NotBlank(message = "휴대전화 번호는 필수 입력값입니다.")
+	@Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하는 11자리 숫자여야 합니다.")
+	@Schema(description = "휴대전화 번호", example = "01012341234")
+	String phone,
+
+	@NotBlank(message = "간편비밀번호는 필수 입력값입니다.")
+	@Pattern(
+		regexp = "^(?=\\d{6}$)(?!.*(?:012|123|234|345|456|567|678|789|987|876|765|654|543|432|321|210))(?!.*(.)\\1\\1)\\d{6}$",
+		message = "간편비밀번호는 6자리 숫자이며, 3자 이상 연속되거나 반복되는 숫자는 사용할 수 없습니다."
+	)
+	@Schema(
+		description = "간편비밀번호 (6자리 숫자, 연속/반복 숫자 3자 이상 금지)",
+		example = "135790",
+		pattern = "^\\d{6}$"
+	)
+	String password
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/dto/response/LoginResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/dto/response/LoginResponse.java
@@ -1,4 +1,4 @@
-package laughcandidate.yellowribbonbe.auth.dto;
+package laughcandidate.yellowribbonbe.auth.dto.response;
 
 import lombok.Builder;
 

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/dto/response/PhoneVerificationResultResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/dto/response/PhoneVerificationResultResponse.java
@@ -1,0 +1,15 @@
+package laughcandidate.yellowribbonbe.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+
+@Schema(name = "PhoneVerificationResultResponse: 전화번호 인증 정보 응답 Dto")
+public record PhoneVerificationResultResponse(
+	@Schema(description = "인증 번호", example = "1djnf3jk3f")
+	String code,
+
+	@Email
+	@Schema(description = "서버 이메일 주소", example = "laughcandidate.verify@gmail.com")
+	String emailAddress
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/dto/response/RegisterResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/dto/response/RegisterResponse.java
@@ -1,0 +1,19 @@
+package laughcandidate.yellowribbonbe.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "RegisterResponse: 회원가입 응답 Dto")
+public record RegisterResponse(
+	@Schema(description = "유저 식별 값입니다,", example = "1fq23")
+	String uid,
+	@Schema(description = "로그인 성공한 유저의 권한입니다.", example = "ADMIN")
+	String role,
+	@NotNull
+	@Schema(description = "JWT Access 토큰입니다.", example = "accessToken")
+	String accessToken,
+	@NotNull
+	@Schema(description = "JWT Refresh 토큰입니다.", example = "refreshToken")
+	String refreshToken
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/filter/CustomUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/filter/CustomUsernamePasswordAuthenticationFilter.java
@@ -17,8 +17,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import laughcandidate.yellowribbonbe.auth.jwt.dto.UserTokenResponse;
 import laughcandidate.yellowribbonbe.auth.service.CustomUserDetails;
-import laughcandidate.yellowribbonbe.auth.dto.LoginRequest;
-import laughcandidate.yellowribbonbe.auth.dto.LoginResponse;
+import laughcandidate.yellowribbonbe.auth.dto.request.LoginRequest;
+import laughcandidate.yellowribbonbe.auth.dto.response.LoginResponse;
 import laughcandidate.yellowribbonbe.auth.util.ResponseUtil;
 import laughcandidate.yellowribbonbe.global.exception.CustomException;
 import laughcandidate.yellowribbonbe.global.exception.errorCode.AuthErrorCode;

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/jwt/TokenProvider.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/jwt/TokenProvider.java
@@ -30,8 +30,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import laughcandidate.yellowribbonbe.auth.util.ResponseUtil;
 import laughcandidate.yellowribbonbe.global.exception.CustomException;
 import laughcandidate.yellowribbonbe.global.exception.errorCode.AuthErrorCode;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jakarta.servlet.http.HttpServletResponse;
+import laughcandidate.yellowribbonbe.user.entity.Role;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -49,8 +52,16 @@ public class TokenProvider {
 
 	public UserTokenResponse createLoginToken(final String uid, final Long userId, final String role) {
 
-		String accessToken = createAccessToken(uid, role);
-		String refreshToken = createRefreshToken(uid, role);
+		String accessToken;
+		String refreshToken;
+
+		if (role.equals(Role.TEMP_USER.getRole())) {
+			accessToken = createAccessToken(uid, role, TEMP_ACCESS_TOKEN_EXPIRATION_MINUTE * MINUTE_IN_MILLISECONDS);
+			refreshToken = createRefreshToken(uid, role, TEMP_REFRESH_TOKEN_EXPIRATION_DAYS * DAYS_IN_MILLISECONDS);
+		} else {
+			accessToken = createAccessToken(uid, role, ACCESS_TOKEN_EXPIRATION_MINUTE * MINUTE_IN_MILLISECONDS);
+			refreshToken = createRefreshToken(uid, role, REFRESH_TOKEN_EXPIRATION_DAYS * DAYS_IN_MILLISECONDS);
+		}
 
 		saveRefreshToken(uid, refreshToken);
 		saveUserId(uid, userId);
@@ -61,12 +72,12 @@ public class TokenProvider {
 		);
 	}
 
-	public String createAccessToken(final String uid, final String role) {
-		return createToken(uid, role, ACCESS_TOKEN_EXPIRATION_MINUTE * MINUTE_IN_MILLISECONDS);
+	public String createAccessToken(final String uid, final String role, final long expiredTime) {
+		return createToken(uid, role, expiredTime);
 	}
 
-	public String createRefreshToken(final String uid, final String role) {
-		return createToken(uid, role, REFRESH_TOKEN_EXPIRATION_DAYS * DAYS_IN_MILLISECONDS);
+	public String createRefreshToken(final String uid, final String role, final long expiredTime) {
+		return createToken(uid, role, expiredTime);
 	}
 
 	public String resolveAccessToken(HttpServletRequest request) {
@@ -99,11 +110,12 @@ public class TokenProvider {
 		return false;
 	}
 
-	public Authentication getAuthenticationByAccessToken(String accessToken, HttpServletResponse response, ObjectMapper objectMapper) throws java.io.IOException {
+	public Authentication getAuthenticationByAccessToken(String accessToken, HttpServletResponse response,
+		ObjectMapper objectMapper) throws java.io.IOException {
 		Claims claims = getClaimsFromToken(accessToken);
 		String uid = claims.getSubject();
 		String role = claims.get("role", String.class);
-		
+
 		try {
 			Long userId = getUserId(uid);
 			CustomUserDetails customUserDetails = CustomUserDetails.fromClaims(uid, userId, role);

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/service/AuthService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/service/AuthService.java
@@ -1,7 +1,12 @@
 package laughcandidate.yellowribbonbe.auth.service;
 
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import laughcandidate.yellowribbonbe.auth.dto.response.PhoneVerificationResultResponse;
+import laughcandidate.yellowribbonbe.auth.util.GeneratorRandomUtil;
 import laughcandidate.yellowribbonbe.global.exception.CustomException;
 import laughcandidate.yellowribbonbe.global.exception.errorCode.AuthErrorCode;
 import laughcandidate.yellowribbonbe.user.repository.UserRepository;
@@ -11,7 +16,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthService {
 
+	private final EmailService emailService;
 	private final UserRepository userRepository;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	public void checkPhoneDuplicate(String phone) {
 		boolean isPhoneExists = userRepository.existsByPhone(phone);
@@ -19,5 +26,14 @@ public class AuthService {
 		if (isPhoneExists) {
 			throw new CustomException(AuthErrorCode.PHONE_DUPLICATED);
 		}
+	}
+
+	public PhoneVerificationResultResponse sendVerificationCode(String phone) {
+		String code = GeneratorRandomUtil.generateRandomNum();
+
+		redisTemplate.opsForValue().set(phone, code, Duration.ofMinutes(5));
+		String emailAddress = emailService.getServerEmail();
+
+		return new PhoneVerificationResultResponse(code,emailAddress);
 	}
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/service/AuthService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/service/AuthService.java
@@ -6,13 +6,19 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
 import laughcandidate.yellowribbonbe.auth.dto.response.PhoneVerificationResultResponse;
+import laughcandidate.yellowribbonbe.auth.dto.response.RegisterResponse;
+import laughcandidate.yellowribbonbe.auth.jwt.TokenProvider;
+import laughcandidate.yellowribbonbe.auth.jwt.dto.UserTokenResponse;
 import laughcandidate.yellowribbonbe.auth.util.GeneratorRandomUtil;
 import laughcandidate.yellowribbonbe.global.exception.CustomException;
 import laughcandidate.yellowribbonbe.global.exception.errorCode.AuthErrorCode;
+import laughcandidate.yellowribbonbe.user.entity.Role;
+import laughcandidate.yellowribbonbe.user.entity.User;
 import laughcandidate.yellowribbonbe.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -23,6 +29,8 @@ public class AuthService {
 	private final EmailService emailService;
 	private final UserRepository userRepository;
 	private final RedisTemplate<String, String> redisTemplate;
+	private final PasswordEncoder passwordEncoder;
+	private final TokenProvider tokenProvider;
 
 	public void checkPhoneDuplicate(String phone) {
 		boolean isPhoneExists = userRepository.existsByPhone(phone);
@@ -64,5 +72,29 @@ public class AuthService {
 		redisTemplate.delete(PREFIX_VERIFICATION_TIME + phone);
 
 		redisTemplate.opsForValue().set(phone, VERIFIED, Duration.ofMinutes(VERIFICATION_TIME));
+	}
+
+	public RegisterResponse register(String name, String phone, String password) {
+		String isVerified = redisTemplate.opsForValue().get(phone);
+
+		if (isVerified == null || !isVerified.equals(VERIFIED)) {
+			throw new CustomException(AuthErrorCode.ACCESS_DENIED);
+		}
+
+		String uid = GeneratorRandomUtil.generateRandomUid();
+
+		User user = User.builder()
+			.name(name)
+			.phone(phone)
+			.password(passwordEncoder.encode(password))
+			.role(Role.TEMP_USER)
+			.uid(uid)
+			.build();
+
+		userRepository.save(user);
+
+		UserTokenResponse token = tokenProvider.createLoginToken(uid, user.getId(), user.getRole().getRole());
+
+		return new RegisterResponse(uid, user.getRole().getRole(), token.accessToken(), token.refreshToken());
 	}
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/service/AuthService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/service/AuthService.java
@@ -1,10 +1,14 @@
 package laughcandidate.yellowribbonbe.auth.service;
 
+import static laughcandidate.yellowribbonbe.auth.constants.EmailVerificationConstant.*;
+
 import java.time.Duration;
+import java.time.LocalDateTime;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import jakarta.transaction.Transactional;
 import laughcandidate.yellowribbonbe.auth.dto.response.PhoneVerificationResultResponse;
 import laughcandidate.yellowribbonbe.auth.util.GeneratorRandomUtil;
 import laughcandidate.yellowribbonbe.global.exception.CustomException;
@@ -28,12 +32,37 @@ public class AuthService {
 		}
 	}
 
+	@Transactional
 	public PhoneVerificationResultResponse sendVerificationCode(String phone) {
 		String code = GeneratorRandomUtil.generateRandomNum();
+		LocalDateTime now = LocalDateTime.now();
 
-		redisTemplate.opsForValue().set(phone, code, Duration.ofMinutes(5));
+		redisTemplate.opsForValue().set(PREFIX_VERIFICATION_CODE + phone, code, Duration.ofMinutes(VERIFICATION_TIME));
+		redisTemplate.opsForValue().set(PREFIX_VERIFICATION_TIME + phone, now.toString(), Duration.ofMinutes(VERIFICATION_TIME));
 		String emailAddress = emailService.getServerEmail();
 
 		return new PhoneVerificationResultResponse(code,emailAddress);
+	}
+
+	@Transactional
+	public void verifyCode(String phone) {
+		String code = redisTemplate.opsForValue().get(PREFIX_VERIFICATION_CODE + phone);
+		String time = redisTemplate.opsForValue().get(PREFIX_VERIFICATION_TIME + phone);
+		
+		if(code == null || time == null) {
+			throw new CustomException(AuthErrorCode.INVALID_VERIFICATION_CODE);
+		}
+
+		LocalDateTime createdAt = LocalDateTime.parse(time);
+		boolean result = emailService.extractCodeByPhoneNumber(code, phone, createdAt);
+
+		if (!result) {
+			throw new CustomException(AuthErrorCode.INVALID_VERIFICATION_CODE);
+		}
+
+		redisTemplate.delete(PREFIX_VERIFICATION_CODE + phone);
+		redisTemplate.delete(PREFIX_VERIFICATION_TIME + phone);
+
+		redisTemplate.opsForValue().set(phone, VERIFIED, Duration.ofMinutes(VERIFICATION_TIME));
 	}
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/service/AuthService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/service/AuthService.java
@@ -1,0 +1,23 @@
+package laughcandidate.yellowribbonbe.auth.service;
+
+import org.springframework.stereotype.Service;
+
+import laughcandidate.yellowribbonbe.global.exception.CustomException;
+import laughcandidate.yellowribbonbe.global.exception.errorCode.AuthErrorCode;
+import laughcandidate.yellowribbonbe.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final UserRepository userRepository;
+
+	public void checkPhoneDuplicate(String phone) {
+		boolean isPhoneExists = userRepository.existsByPhone(phone);
+
+		if (isPhoneExists) {
+			throw new CustomException(AuthErrorCode.PHONE_DUPLICATED);
+		}
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/service/EmailService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/service/EmailService.java
@@ -1,9 +1,32 @@
 package laughcandidate.yellowribbonbe.auth.service;
 
+import static laughcandidate.yellowribbonbe.auth.constants.EmailVerificationConstant.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Service;
 
+import jakarta.mail.Address;
+import jakarta.mail.BodyPart;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import jakarta.mail.search.ComparisonTerm;
+import jakarta.mail.search.ReceivedDateTerm;
+import jakarta.mail.search.SearchTerm;
+import laughcandidate.yellowribbonbe.auth.constants.EmailVerificationConstant;
 import laughcandidate.yellowribbonbe.auth.dto.ImapCredentials;
 import lombok.RequiredArgsConstructor;
 
@@ -16,5 +39,167 @@ public class EmailService {
 
 	public String getServerEmail() {
 		return imapCredentials.userName();
+	}
+
+	public boolean extractCodeByPhoneNumber(String code, String phone, LocalDateTime since) {
+		try {
+			Store store = connectToEmailStore();
+			Folder inbox = openInboxFolder(store);
+			if (!searchTokenInEmails(inbox, code, phone, since)) {
+				closeConnections(inbox, store);
+				return false;
+			}
+			closeConnections(inbox, store);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	private Store connectToEmailStore() throws MessagingException {
+		Session session = Session.getDefaultInstance(imapConnectionProperties);
+		Store store = session.getStore(IMAP_PROTOCOL);
+		store.connect(imapCredentials.userName(), imapCredentials.password());
+		return store;
+	}
+
+	private Folder openInboxFolder(Store store) throws MessagingException {
+		Folder inbox = store.getFolder(INBOX);
+		inbox.open(Folder.READ_ONLY);
+		return inbox;
+	}
+
+	private boolean searchTokenInEmails(Folder inbox, String code, String phone, LocalDateTime since)
+		throws MessagingException {
+		Date sinceDate = Date.from(since.atZone(ZoneId.systemDefault()).toInstant());
+		SearchTerm timeTerm = new ReceivedDateTerm(ComparisonTerm.GE, sinceDate);
+		Message[] messages = inbox.search(timeTerm);
+
+		Arrays.sort(messages, (a, b) -> {
+			try {
+				Date dateA = a.getReceivedDate();
+				Date dateB = b.getReceivedDate();
+
+				if (dateA == null && dateB == null) {
+					return 0;
+				}
+				if (dateA == null) {
+					return 1;
+				}
+				if (dateB == null) {
+					return -1;
+				}
+
+				return dateB.compareTo(dateA);
+			} catch (MessagingException e) {
+				return 0;
+			}
+		});
+
+		for (Message message : messages) {
+			if (isFromPhoneNumber(message, phone)) {
+				String mailCode = extractCodeFromMessageContent(message);
+				if (mailCode != null && code.equals(mailCode)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private boolean isFromPhoneNumber(Message message, String phone) {
+		try {
+			Address[] from = message.getFrom();
+			if (from == null || from.length == 0) {
+				return false;
+			}
+
+			String fromAddress = from[0].toString();
+			return fromAddress.contains(phone + AT);
+
+		} catch (MessagingException e) {
+			return false;
+		}
+	}
+
+	private String extractCodeFromMessageContent(Message message) {
+		try {
+			// LG U+: 단순 텍스트 본문
+			if (message.isMimeType(TEXT)) {
+				String content = (String)message.getContent();
+				return extractCode(content);
+			}
+
+			// KT: multipart (본문 + 첨부파일)
+			if (message.isMimeType(MULTIPART)) {
+				return extractFromMultipart(message);
+			}
+
+			return null;
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	private String extractFromMultipart(Message message) throws MessagingException, IOException {
+		Multipart multipart = (Multipart)message.getContent();
+
+		for (int i = 0; i < multipart.getCount(); i++) {
+			BodyPart bodyPart = multipart.getBodyPart(i);
+
+			if (bodyPart.isMimeType(TEXT)) {
+				String content = (String)bodyPart.getContent();
+				String code = extractCode(content);
+				if (code != null) {
+					return code;
+				}
+			}
+
+			// 2. 텍스트 파일 첨부에서 토큰 찾기 (아이폰 KT)
+			if (isTextFile(bodyPart)) {
+				InputStream inputStream = bodyPart.getInputStream();
+				String content = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+				String code = extractCode(content);
+				if (code != null) {
+					return code;
+				}
+			}
+		}
+		return null;
+	}
+
+	private boolean isTextFile(BodyPart bodyPart) throws MessagingException {
+		String fileName = bodyPart.getFileName();
+		return fileName != null && fileName.toLowerCase().endsWith(TXT);
+	}
+
+	private String extractCode(String content) {
+		if (content == null) {
+			return null;
+		}
+
+		Pattern pattern = Pattern.compile(EmailVerificationConstant.VERIFICATION_CODE_PATTERN);
+		Matcher matcher = pattern.matcher(content);
+		if (matcher.find()) {
+			return matcher.group(1);
+		}
+		return null;
+	}
+
+	private void closeConnections(Folder inbox, Store store) {
+		try {
+			if (inbox != null && inbox.isOpen()) {
+				inbox.close(false);
+			}
+		} catch (MessagingException e) {
+		}
+
+		try {
+			if (store != null && store.isConnected()) {
+				store.close();
+			}
+		} catch (MessagingException e) {
+		}
 	}
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/service/EmailService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/service/EmailService.java
@@ -1,0 +1,20 @@
+package laughcandidate.yellowribbonbe.auth.service;
+
+import java.util.Properties;
+
+import org.springframework.stereotype.Service;
+
+import laughcandidate.yellowribbonbe.auth.dto.ImapCredentials;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+	private final Properties imapConnectionProperties;
+	private final ImapCredentials imapCredentials;
+
+	public String getServerEmail() {
+		return imapCredentials.userName();
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/util/GeneratorRandomUtil.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/util/GeneratorRandomUtil.java
@@ -14,4 +14,16 @@ public class GeneratorRandomUtil {
 		int randomNumber = RANDOM.nextInt(1000000);
 		return String.format("%06d", randomNumber);
 	}
+
+	public static String generateRandomUid() {
+		String characters = "abcdefghijklmnopqrstuvwxyz0123456789";
+		StringBuilder uid = new StringBuilder();
+		
+		for (int i = 0; i < 6; i++) {
+			int index = RANDOM.nextInt(characters.length());
+			uid.append(characters.charAt(index));
+		}
+		
+		return uid.toString();
+	}
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/auth/util/GeneratorRandomUtil.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/auth/util/GeneratorRandomUtil.java
@@ -1,0 +1,17 @@
+package laughcandidate.yellowribbonbe.auth.util;
+
+import java.security.SecureRandom;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GeneratorRandomUtil {
+
+	private static final SecureRandom RANDOM = new SecureRandom();
+
+	public static String generateRandomNum() {
+		int randomNumber = RANDOM.nextInt(1000000);
+		return String.format("%06d", randomNumber);
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/global/config/ImapConfig.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/config/ImapConfig.java
@@ -1,0 +1,52 @@
+package laughcandidate.yellowribbonbe.global.config;
+
+import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import laughcandidate.yellowribbonbe.auth.dto.ImapCredentials;
+
+@Configuration
+public class ImapConfig {
+
+	@Value("${spring.mail.properties.mail.imap.host}")
+	private String host;
+
+	@Value("${spring.mail.properties.mail.imap.port}")
+	private int port;
+
+	@Value("${spring.mail.username}")
+	private String username;
+
+	@Value("${spring.mail.password}")
+	private String password;
+
+	@Value("${spring.mail.properties.mail.imap.ssl.enable}")
+	private boolean sslEnable;
+
+	@Value("${spring.mail.properties.mail.imap.connectiontimeout}")
+	private int connectionTimeout;
+
+	@Value("${spring.mail.properties.mail.imap.timeout}")
+	private int timeout;
+
+	@Bean
+	public Properties imapConnectionProperties() {
+		Properties props = new Properties();
+		props.put("mail.store.protocol", "imaps");
+		props.put("mail.imaps.host", host);
+		props.put("mail.imaps.port", String.valueOf(port));
+		props.put("mail.imaps.ssl.enable", sslEnable);
+		props.put("mail.imaps.connectiontimeout", connectionTimeout);
+		props.put("mail.imaps.timeout", timeout);
+
+		return props;
+	}
+
+	@Bean
+	public ImapCredentials imapCredentials() {
+		return new ImapCredentials(username, password);
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/global/config/SecurityConfig.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
 		"/webjars/**",
 		"/actuator/**",
 		"/auth/login",
-		"/auth/check-phone"
+		"/auth/check-phone",
+		"/auth/send-code"
 	};
 
 	private static final String[] BLACKLIST = {

--- a/src/main/java/laughcandidate/yellowribbonbe/global/config/SecurityConfig.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/config/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
 		"/actuator/**",
 		"/auth/login",
 		"/auth/check-phone",
-		"/auth/send-code"
+		"/auth/send-code",
+		"/auth/verify-code"
 	};
 
 	private static final String[] BLACKLIST = {

--- a/src/main/java/laughcandidate/yellowribbonbe/global/config/SecurityConfig.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
 		"/auth/login",
 		"/auth/check-phone",
 		"/auth/send-code",
-		"/auth/verify-code"
+		"/auth/verify-code",
+		"/auth/register"
 	};
 
 	private static final String[] BLACKLIST = {

--- a/src/main/java/laughcandidate/yellowribbonbe/global/config/SecurityConfig.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
 		"/swagger-resources/**",
 		"/webjars/**",
 		"/actuator/**",
-		"/auth/login"
+		"/auth/login",
+		"/auth/check-phone"
 	};
 
 	private static final String[] BLACKLIST = {

--- a/src/main/java/laughcandidate/yellowribbonbe/global/constants/TokenConstant.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/constants/TokenConstant.java
@@ -5,7 +5,9 @@ public class TokenConstant {
 	public static final int MINUTE_IN_MILLISECONDS = 60 * 1000;
 	public static final long DAYS_IN_MILLISECONDS = 24 * 60 * 60 * 1000L;
 	public static final int ACCESS_TOKEN_EXPIRATION_MINUTE = 20;
+	public static final int TEMP_ACCESS_TOKEN_EXPIRATION_MINUTE = 30;
 	public static final int REFRESH_TOKEN_EXPIRATION_DAYS = 14;
+	public static final int TEMP_REFRESH_TOKEN_EXPIRATION_DAYS = 1;
 	public static final String REFRESH_TOKEN_PREFIX = "refresh_token_";
 	public static final String USER_ID_PREFIX = "user_id_";
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/AuthErrorCode.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/AuthErrorCode.java
@@ -20,6 +20,9 @@ public enum AuthErrorCode implements ErrorCode {
 
     // 404
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "A-006", "회원을 찾을 수 없습니다."),
+
+    // 409
+    PHONE_DUPLICATED(HttpStatus.CONFLICT, "A-007", "이미 존재하는 전화번호입니다."),
     ;
 
     private HttpStatus httpStatus;

--- a/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/AuthErrorCode.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/AuthErrorCode.java
@@ -9,23 +9,26 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
 
-    // 401
-    WRONG_ID_PW(HttpStatus.UNAUTHORIZED, "A-001", "아이디 혹은 비밀번호가 올바르지 않습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A-002", "유효하지 않은 토큰입니다."),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A-003", "토큰이 만료되었습니다."),
+	// 400
+	INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "A-008", "유효하지 않은 인증번호입니다."),
 
-    // 403
-    INCORRECT_CLAIM_TOKEN(HttpStatus.FORBIDDEN, "A-004", "잘못된 토큰입니다."),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A-005", "접근이 거부되었습니다."),
+	// 401
+	WRONG_ID_PW(HttpStatus.UNAUTHORIZED, "A-001", "아이디 혹은 비밀번호가 올바르지 않습니다."),
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A-002", "유효하지 않은 토큰입니다."),
+	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A-003", "토큰이 만료되었습니다."),
 
-    // 404
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "A-006", "회원을 찾을 수 없습니다."),
+	// 403
+	INCORRECT_CLAIM_TOKEN(HttpStatus.FORBIDDEN, "A-004", "잘못된 토큰입니다."),
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "A-005", "접근이 거부되었습니다."),
 
-    // 409
-    PHONE_DUPLICATED(HttpStatus.CONFLICT, "A-007", "이미 존재하는 전화번호입니다."),
-    ;
+	// 404
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "A-006", "회원을 찾을 수 없습니다."),
 
-    private HttpStatus httpStatus;
-    private String code;
-    private String message;
+	// 409
+	PHONE_DUPLICATED(HttpStatus.CONFLICT, "A-007", "이미 존재하는 전화번호입니다."),
+	;
+
+	private HttpStatus httpStatus;
+	private String code;
+	private String message;
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/user/entity/User.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/user/entity/User.java
@@ -45,11 +45,11 @@ public class User extends BaseEntity {
 	private boolean isDeleted = false;
 
 	@Builder
-	public User(String name, String password, String phone,
-		String uid) {
+	public User(String name, String password, String phone, String uid, Role role) {
 		this.name = name;
 		this.password = password;
 		this.phone = phone;
 		this.uid = uid;
+		this.role = role;
 	}
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/user/repository/UserRepository.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import laughcandidate.yellowribbonbe.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByPhoneAndIsDeletedFalse(String loginId);
+
+	boolean existsByPhone(String phone);
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -29,6 +29,19 @@ spring:
       repositories:
         enabled: false
 
+  mail:
+    username: test@gmail.com
+    password: testtesttesttest
+    properties:
+      mail:
+        imap:
+          host: imap.gmail.com
+          port: 993
+          ssl:
+            enable: true
+          connectiontimeout: 10000
+          timeout: 10000
+
 security:
   jwt:
     token:


### PR DESCRIPTION
## 📄 PR 내용

- 휴대폰 인증과 간편 비밀번호를 통해 회원가입을 진행하면 임시회원으로 분류
- 사용자가 로그인 시 Role이 임시회원일 경우 사업자 연동으로 페이지 리다이렉션 예정
- LG U+와 KT만 현재 이메일 인증 확인 가능

## 📝 수정 상세 내용

- 로그인 시 Role이 임시회원 여부에 따라 AT, RT 토큰 유효기간을 다르게 설정
- Redis에 인증번호 성공 여부 상태 저장

## ✅ 체크리스트

- [x] 로그인 시 Role이 임시회원 여부에 따라 AT, RT 토큰 유효기간을 다르게 설정
- [x] Redis에 인증번호 성공 여부 상태 저장

## 📍 레퍼런스

<img width="543" height="199" alt="스크린샷 2025-08-31 오후 3 22 19" src="https://github.com/user-attachments/assets/a0bad420-a0ac-4d8d-9db9-6b22985b47c4" />