### PR TITLE
[FEAT] 사용자 권한에 따른 사업자 연동

### DIFF
--- a/src/main/java/laughcandidate/yellowribbonbe/business/client/BusinessValidationClient.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/client/BusinessValidationClient.java
@@ -1,0 +1,19 @@
+package laughcandidate.yellowribbonbe.business.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import laughcandidate.yellowribbonbe.business.dto.request.BusinessValidationRequest;
+import laughcandidate.yellowribbonbe.business.dto.response.BusinessValidationResponse;
+
+@FeignClient(name = "businessValidationClient", url = "${open-api.url}")
+public interface BusinessValidationClient {
+	
+	@PostMapping
+	BusinessValidationResponse validateBusiness(
+		@RequestParam String serviceKey,
+		@RequestBody BusinessValidationRequest request
+	);
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/config/FeignConfig.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/config/FeignConfig.java
@@ -1,0 +1,9 @@
+package laughcandidate.yellowribbonbe.business.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "laughcandidate.yellowribbonbe.business.client")
+public class FeignConfig {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/controller/BusinessController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/controller/BusinessController.java
@@ -1,0 +1,58 @@
+package laughcandidate.yellowribbonbe.business.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import laughcandidate.yellowribbonbe.auth.service.CustomUserDetails;
+import laughcandidate.yellowribbonbe.business.dto.request.ConnectOptionalRequest;
+import laughcandidate.yellowribbonbe.business.dto.request.ConnectRequiredRequest;
+import laughcandidate.yellowribbonbe.business.dto.response.ConnectResponse;
+import laughcandidate.yellowribbonbe.business.service.BusinessService;
+import laughcandidate.yellowribbonbe.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "사업자")
+@RestController
+@RequestMapping("/business")
+@RequiredArgsConstructor
+public class BusinessController {
+
+	private final BusinessService businessService;
+
+	@PostMapping("/connect/required")
+	@Operation(
+		summary = "사업자 연동 API",
+		description = "사업장 연동")
+	public ResponseEntity<ApiResponse<ConnectResponse>> connectBusinessRequired(
+		@RequestBody @Valid ConnectRequiredRequest connectRequiredRequest,
+		@AuthenticationPrincipal
+		CustomUserDetails customUserDetails) {
+
+		ConnectResponse connectResponse = businessService.connectBusinessRequired(connectRequiredRequest.businessNo(),
+			connectRequiredRequest.ownerName(),
+			connectRequiredRequest.startDate(), connectRequiredRequest.businessName(), connectRequiredRequest.isLast(),
+			customUserDetails.getUserId());
+		return ResponseEntity.ok(ApiResponse.created(connectResponse));
+	}
+
+	@PostMapping("/connect/optional")
+	@Operation(
+		summary = "사업자 연동 API",
+		description = "사업장 연동")
+	public ResponseEntity<ApiResponse<Void>> connectBusinessOptional(
+		@RequestBody @Valid ConnectOptionalRequest connectOptionalRequest,
+		@AuthenticationPrincipal
+		CustomUserDetails customUserDetails) {
+
+		businessService.connectBusinessOptional(connectOptionalRequest.businessNo(), connectOptionalRequest.ownerName(),
+			connectOptionalRequest.startDate(), connectOptionalRequest.businessName(), customUserDetails.getUserId());
+		return ResponseEntity.ok(ApiResponse.noContent());
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/dto/BusinessInfo.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/dto/BusinessInfo.java
@@ -1,0 +1,8 @@
+package laughcandidate.yellowribbonbe.business.dto;
+
+public record BusinessInfo(
+	String b_no,
+	String p_nm,
+	String start_dt
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/dto/BusinessValidationData.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/dto/BusinessValidationData.java
@@ -1,0 +1,6 @@
+package laughcandidate.yellowribbonbe.business.dto;
+
+public record BusinessValidationData(
+	String valid
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/dto/request/BusinessValidationRequest.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/dto/request/BusinessValidationRequest.java
@@ -1,0 +1,10 @@
+package laughcandidate.yellowribbonbe.business.dto.request;
+
+import java.util.List;
+
+import laughcandidate.yellowribbonbe.business.dto.BusinessInfo;
+
+public record BusinessValidationRequest(
+	List<BusinessInfo> businesses
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/dto/request/ConnectOptionalRequest.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/dto/request/ConnectOptionalRequest.java
@@ -1,0 +1,24 @@
+package laughcandidate.yellowribbonbe.business.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(name = "ConnectOptionalRequest: 사업자 연동 요청 Dto")
+public record ConnectOptionalRequest(
+	@NotBlank(message = "사업자 번호는 필수 입력값입니다.")
+	@Schema(description = "사업자 번호", example = "12345678")
+	String businessNo,
+
+	@NotBlank(message = "대표자명은 필수 입력값입니다.")
+	@Schema(description = "대표자 이름", example = "김돌돌")
+	String ownerName,
+
+	@NotBlank(message = "개업일자는 필수 입력값입니다.")
+	@Schema(description = "개업일자", example = "20250101")
+	String startDate,
+
+	@NotBlank(message = "사업자명은 필수 입력값입니다.")
+	@Schema(description = "사업자 이름", example = "돌돌")
+	String businessName
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/dto/request/ConnectRequiredRequest.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/dto/request/ConnectRequiredRequest.java
@@ -1,0 +1,29 @@
+package laughcandidate.yellowribbonbe.business.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "ConnectRequiredRequest: 임시 사업자 연동 요청 Dto")
+public record ConnectRequiredRequest(
+	@NotBlank(message = "사업자 번호는 필수 입력값입니다.")
+	@Schema(description = "사업자 번호", example = "12345678")
+	String businessNo,
+
+	@NotBlank(message = "대표자명은 필수 입력값입니다.")
+	@Schema(description = "대표자 이름", example = "김돌돌")
+	String ownerName,
+
+	@NotBlank(message = "개업일자는 필수 입력값입니다.")
+	@Schema(description = "개업일자", example = "20250101")
+	String startDate,
+
+	@NotBlank(message = "사업자명은 필수 입력값입니다.")
+	@Schema(description = "사업자 이름", example = "돌돌")
+	String businessName,
+
+	@NotNull(message = "마지막 값 여부는 필수 입력값입니다.")
+	@Schema(description = "마지막 값 여부", example = "true")
+	boolean isLast
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/dto/response/BusinessValidationResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/dto/response/BusinessValidationResponse.java
@@ -1,0 +1,13 @@
+package laughcandidate.yellowribbonbe.business.dto.response;
+
+import java.util.List;
+
+import laughcandidate.yellowribbonbe.business.dto.BusinessValidationData;
+
+public record BusinessValidationResponse(
+	int request_cnt,
+	int valid_cnt,
+	String status_code,
+	List<BusinessValidationData> data
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/dto/response/ConnectResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/dto/response/ConnectResponse.java
@@ -1,0 +1,18 @@
+package laughcandidate.yellowribbonbe.business.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "ConnectResponse: 임시회원의 사업자 연동 응답 Dto")
+public record ConnectResponse(
+	@NotNull(message = "마지막 값 여부는 필수 입력값입니다.")
+	@Schema(description = "마지막 값 여부", example = "true")
+	boolean isLast,
+
+	@Schema(description = "AT", example = "accessToken")
+	String accessToken,
+
+	@Schema(description = "RT", example = "refreshToken")
+	String refreshToken
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/entity/Business.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/entity/Business.java
@@ -1,0 +1,55 @@
+package laughcandidate.yellowribbonbe.business.entity;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import laughcandidate.yellowribbonbe.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Table(name = "BUSINESS")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Business {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "business_id")
+	private Long id;
+
+	@Column(name = "business_no", unique = true)
+	private String businessNo;
+
+	@Column(name = "owner_name")
+	private String ownerName;
+
+	@Column(name = "start_date")
+	private LocalDate startDate;
+
+	@Column(name = "business_name")
+	private String businessName;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Builder
+	public Business(String businessName, String businessNo, String ownerName, LocalDate startDate, User user) {
+		this.businessName = businessName;
+		this.businessNo = businessNo;
+		this.ownerName = ownerName;
+		this.startDate = startDate;
+		this.user = user;
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/repository/BusinessRepository.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/repository/BusinessRepository.java
@@ -1,0 +1,10 @@
+package laughcandidate.yellowribbonbe.business.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import laughcandidate.yellowribbonbe.business.entity.Business;
+
+public interface BusinessRepository extends JpaRepository<Business, Long> {
+
+	boolean existsByBusinessNo(String businessNo);
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/service/BusinessService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/service/BusinessService.java
@@ -1,0 +1,99 @@
+package laughcandidate.yellowribbonbe.business.service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import laughcandidate.yellowribbonbe.auth.jwt.TokenProvider;
+import laughcandidate.yellowribbonbe.auth.jwt.dto.UserTokenResponse;
+import laughcandidate.yellowribbonbe.business.dto.BusinessInfo;
+import laughcandidate.yellowribbonbe.business.dto.request.BusinessValidationRequest;
+import laughcandidate.yellowribbonbe.business.dto.response.BusinessValidationResponse;
+import laughcandidate.yellowribbonbe.business.dto.response.ConnectResponse;
+import laughcandidate.yellowribbonbe.business.entity.Business;
+import laughcandidate.yellowribbonbe.business.repository.BusinessRepository;
+import laughcandidate.yellowribbonbe.business.util.OpenApiUtil;
+import laughcandidate.yellowribbonbe.global.exception.CustomException;
+import laughcandidate.yellowribbonbe.global.exception.errorCode.AuthErrorCode;
+import laughcandidate.yellowribbonbe.global.exception.errorCode.BusinessErrorCode;
+import laughcandidate.yellowribbonbe.user.entity.Role;
+import laughcandidate.yellowribbonbe.user.entity.User;
+import laughcandidate.yellowribbonbe.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BusinessService {
+
+	private static final String VERIFIED = "01";
+
+	private final OpenApiUtil openApiUtil;
+	private final BusinessRepository businessRepository;
+	private final UserRepository userRepository;
+	private final TokenProvider tokenProvider;
+
+	public ConnectResponse connectBusinessRequired(String businessNo, String ownerName, String startDate,
+		String businessName,
+		boolean isLast, Long userId) {
+		validateBusiness(businessNo, ownerName, startDate);
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+		LocalDate parsedStartDate = LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+		saveBusiness(businessNo, businessName, ownerName, parsedStartDate, user);
+
+		if (isLast) {
+			user.updateRole();
+			UserTokenResponse token = tokenProvider.createLoginToken(user.getUid(), userId, Role.USER.getRole());
+			return new ConnectResponse(isLast, token.accessToken(), token.refreshToken());
+		}
+
+		return new ConnectResponse(isLast, null, null);
+	}
+
+	public void connectBusinessOptional(String businessNo, String ownerName, String startDate, String businessName,
+		Long userId) {
+		validateBusiness(businessNo, ownerName, startDate);
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(AuthErrorCode.USER_NOT_FOUND));
+
+		LocalDate parsedStartDate = LocalDate.parse(startDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+		saveBusiness(businessNo, businessName, ownerName, parsedStartDate, user);
+	}
+
+	@Transactional
+	protected void saveBusiness(String businessNo, String businessName, String ownerName, LocalDate startDate,
+		User user) {
+		Business business = Business.builder()
+			.businessNo(businessNo)
+			.businessName(businessName)
+			.ownerName(ownerName)
+			.startDate(startDate)
+			.user(user)
+			.build();
+
+		businessRepository.save(business);
+	}
+
+	private void validateBusiness(String businessNo, String ownerName, String startDate) {
+		if (businessRepository.existsByBusinessNo(businessNo)) {
+			throw new CustomException(BusinessErrorCode.BUSINESS_NO_DUPLICATED);
+		}
+
+		BusinessInfo businessInfo = new BusinessInfo(businessNo, ownerName, startDate);
+		BusinessValidationRequest request = new BusinessValidationRequest(List.of(businessInfo));
+
+		BusinessValidationResponse response = openApiUtil.validateBusiness(request);
+
+		if (response.data().isEmpty() || !VERIFIED.equals(response.data().get(0).valid())) {
+			throw new CustomException(BusinessErrorCode.BUSINESS_NOT_FOUND);
+		}
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/business/util/OpenApiUtil.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/util/OpenApiUtil.java
@@ -1,0 +1,23 @@
+package laughcandidate.yellowribbonbe.business.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import laughcandidate.yellowribbonbe.business.client.BusinessValidationClient;
+import laughcandidate.yellowribbonbe.business.dto.request.BusinessValidationRequest;
+import laughcandidate.yellowribbonbe.business.dto.response.BusinessValidationResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OpenApiUtil {
+
+	@Value("${open-api.key}")
+	private String serviceKey;
+	
+	private final BusinessValidationClient businessValidationClient;
+
+	public BusinessValidationResponse validateBusiness(BusinessValidationRequest request) {
+		return businessValidationClient.validateBusiness(serviceKey, request);
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/global/config/SecurityConfig.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import laughcandidate.yellowribbonbe.auth.filter.JwtAuthenticationFilter;
 import laughcandidate.yellowribbonbe.auth.handler.CustomAccessDeniedHandler;
 import laughcandidate.yellowribbonbe.auth.handler.CustomAuthenticationEntryPoint;
 import laughcandidate.yellowribbonbe.auth.jwt.TokenProvider;
+import laughcandidate.yellowribbonbe.user.entity.Role;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -57,6 +58,8 @@ public class SecurityConfig {
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/business/connect/required").hasAuthority(Role.TEMP_USER.getRole())
+				.requestMatchers("/business/connect/optional").hasAuthority(Role.USER.getRole())
 				.requestMatchers(WHITELIST).permitAll()
 				.requestMatchers(BLACKLIST).authenticated()
 				.anyRequest().authenticated())

--- a/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/BusinessErrorCode.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/BusinessErrorCode.java
@@ -1,0 +1,22 @@
+package laughcandidate.yellowribbonbe.global.exception.errorCode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BusinessErrorCode implements ErrorCode{
+
+	// 404
+	BUSINESS_NOT_FOUND(HttpStatus.NOT_FOUND, "B-001", "존재하지 않는 사업자입니다."),
+
+	// 409
+	BUSINESS_NO_DUPLICATED(HttpStatus.CONFLICT, "B-002", "이미 존재하는 사업자 번호입니다."),
+	;
+
+	private HttpStatus httpStatus;
+	private String code;
+	private String message;
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/user/entity/User.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/user/entity/User.java
@@ -52,4 +52,8 @@ public class User extends BaseEntity {
 		this.uid = uid;
 		this.role = role;
 	}
+
+	public void updateRole() {
+		this.role = Role.USER;
+	}
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -46,3 +46,7 @@ security:
   jwt:
     token:
       secret-key: testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest
+
+open-api:
+  url: test
+  key: test


### PR DESCRIPTION
## 📄 PR 내용

- Role에 따른 사업자 연동

## 📝 수정 상세 내용

- 공공데이터 포털을 이용하여 사업자 진위여부 확인
- Role이 임시회원이고 마지막 사업장 연동 시 Role을 USER로 갱신 및 jwt 토큰 재발급
- 권한에 따른 API 접근 설정

## ✅ 체크리스트

- [x] 공공데이터 포털을 이용하여 사업자 진위여부 확인
- [x] Role이 임시회원이고 마지막 사업장 연동 시 Role을 USER로 갱신 및 jwt 토큰 재발급
- [x] 권한에 따른 API 접근 설정

## 📍 레퍼런스

- X