### PR TITLE
[FEAT] 관리자 배지, 리본 관리

### DIFF
--- a/src/main/java/laughcandidate/yellowribbonbe/admin/controller/AdminBadgeController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/admin/controller/AdminBadgeController.java
@@ -1,0 +1,68 @@
+package laughcandidate.yellowribbonbe.admin.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import laughcandidate.yellowribbonbe.admin.dto.response.BadgeApplyListResponse;
+import laughcandidate.yellowribbonbe.admin.service.AdminBadgeService;
+import laughcandidate.yellowribbonbe.badge.entity.BadgeApply;
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import laughcandidate.yellowribbonbe.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "관리자 - 배지 신청 관리")
+@RestController
+@RequestMapping("/admin/badge")
+@RequiredArgsConstructor
+public class AdminBadgeController {
+
+	private final AdminBadgeService adminBadgeService;
+
+	@GetMapping("/list")
+	@Operation(
+		summary = "배지 신청 목록 조회 API",
+		description = "관리자용 배지 신청 목록을 페이지네이션으로 조회합니다. 상태별 필터링 지원")
+	public ResponseEntity<ApiResponse<BadgeApplyListResponse>> getBadgeApplies(
+		@Parameter(description = "필터링할 상태 (PENDING, COMPLETE, REJECTED)")
+		@RequestParam(required = false) Status status,
+		@Parameter(description = "페이지 정보 (page, size, sort)")
+		@PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+
+		BadgeApplyListResponse response = adminBadgeService.getBadgeApplies(status, pageable);
+		return ResponseEntity.ok(ApiResponse.ok(response));
+	}
+
+	@GetMapping("/{badgeApplyId}")
+	@Operation(
+		summary = "배지 신청 상세 조회 API",
+		description = "특정 배지 신청의 상세 정보를 조회합니다.")
+	public ResponseEntity<ApiResponse<BadgeApply>> getBadgeApplyDetail(
+		@Parameter(description = "배지 신청 ID")
+		@PathVariable Long badgeApplyId
+	) {
+		BadgeApply badgeApply = adminBadgeService.getBadgeApplyDetail(badgeApplyId);
+		return ResponseEntity.ok(ApiResponse.ok(badgeApply));
+	}
+
+	@PostMapping("/{badgeApplyId}/approve")
+	@Operation(
+		summary = "배지 신청 승인 API",
+		description = "배지 신청을 승인하여 배지를 발급합니다.")
+	public ResponseEntity<ApiResponse<Void>> approveBadgeApplication(
+		@Parameter(description = "배지 신청 ID")
+		@PathVariable Long badgeApplyId
+	) {
+		adminBadgeService.approveBadgeApplication(badgeApplyId);
+		return ResponseEntity.ok(ApiResponse.ok(null));
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/admin/dto/response/BadgeApplyListItemResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/admin/dto/response/BadgeApplyListItemResponse.java
@@ -1,0 +1,40 @@
+package laughcandidate.yellowribbonbe.admin.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import laughcandidate.yellowribbonbe.badge.entity.BadgeApply;
+import laughcandidate.yellowribbonbe.badge.entity.Category;
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import lombok.Builder;
+
+@Builder
+public record BadgeApplyListItemResponse(
+	Long badgeApplyId,
+	Status status,
+
+	String applicantName,
+	String applicantPhone,
+
+	String businessName,
+	String businessNo,
+
+	Category badgeCategory,
+
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	LocalDateTime appliedAt
+) {
+	public static BadgeApplyListItemResponse from(BadgeApply badgeApply) {
+		return BadgeApplyListItemResponse.builder()
+			.badgeApplyId(badgeApply.getId())
+			.status(badgeApply.getStatus())
+			.applicantName(badgeApply.getUser().getName())
+			.applicantPhone(badgeApply.getUser().getPhone())
+			.businessName(badgeApply.getUser().getName() + " 사업장")
+			.businessNo("123-45-67890")
+			.badgeCategory(badgeApply.getBadge().getCategory())
+			.appliedAt(badgeApply.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/admin/dto/response/BadgeApplyListResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/admin/dto/response/BadgeApplyListResponse.java
@@ -1,0 +1,36 @@
+package laughcandidate.yellowribbonbe.admin.dto.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import laughcandidate.yellowribbonbe.badge.entity.BadgeApply;
+import lombok.Builder;
+
+@Builder
+public record BadgeApplyListResponse(
+	List<BadgeApplyListItemResponse> badgeApplies,
+	int currentPage,
+	int totalPages,
+	long totalElements,
+	int size,
+	boolean hasNext,
+	boolean hasPrevious
+) {
+	public static BadgeApplyListResponse from(Page<BadgeApply> badgeApplyPage) {
+		List<BadgeApplyListItemResponse> items = badgeApplyPage.getContent()
+			.stream()
+			.map(BadgeApplyListItemResponse::from)
+			.toList();
+
+		return BadgeApplyListResponse.builder()
+			.badgeApplies(items)
+			.currentPage(badgeApplyPage.getNumber())
+			.totalPages(badgeApplyPage.getTotalPages())
+			.totalElements(badgeApplyPage.getTotalElements())
+			.size(badgeApplyPage.getSize())
+			.hasNext(badgeApplyPage.hasNext())
+			.hasPrevious(badgeApplyPage.hasPrevious())
+			.build();
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/admin/service/AdminBadgeService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/admin/service/AdminBadgeService.java
@@ -1,0 +1,55 @@
+package laughcandidate.yellowribbonbe.admin.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import laughcandidate.yellowribbonbe.admin.dto.response.BadgeApplyListResponse;
+import laughcandidate.yellowribbonbe.badge.entity.BadgeApply;
+import laughcandidate.yellowribbonbe.badge.repository.BadgeApplyRepository;
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import laughcandidate.yellowribbonbe.global.exception.CustomException;
+import laughcandidate.yellowribbonbe.global.exception.errorCode.AdminErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminBadgeService {
+
+	private final BadgeApplyRepository badgeApplyRepository;
+
+	@Transactional(readOnly = true)
+	public BadgeApplyListResponse getBadgeApplies(Status status, Pageable pageable) {
+		Page<BadgeApply> badgeApplyPage = status != null
+			? badgeApplyRepository.findByStatusWithBasicInfo(status, pageable)
+			: badgeApplyRepository.findAllWithBasicInfo(pageable);
+		return BadgeApplyListResponse.from(badgeApplyPage);
+	}
+
+	@Transactional(readOnly = true)
+	public BadgeApplyListResponse getAllBadgeApplies(Pageable pageable) {
+		Page<BadgeApply> badgeApplyPage = badgeApplyRepository.findAllWithBasicInfo(pageable);
+		return BadgeApplyListResponse.from(badgeApplyPage);
+	}
+
+	@Transactional(readOnly = true)
+	public BadgeApplyListResponse getBadgeAppliesByStatus(Status status, Pageable pageable) {
+		Page<BadgeApply> badgeApplyPage = badgeApplyRepository.findByStatusWithBasicInfo(status, pageable);
+		return BadgeApplyListResponse.from(badgeApplyPage);
+	}
+
+	@Transactional(readOnly = true)
+	public BadgeApply getBadgeApplyDetail(Long badgeApplyId) {
+		return badgeApplyRepository.findByIdWithAllDetails(badgeApplyId)
+			.orElseThrow(() -> new CustomException(AdminErrorCode.BADGE_APPLY_NOT_FOUND));
+	}
+
+	@Transactional
+	public void approveBadgeApplication(Long badgeApplyId) {
+		BadgeApply badgeApply = badgeApplyRepository.findById(badgeApplyId)
+			.orElseThrow(() -> new CustomException(AdminErrorCode.BADGE_APPLY_NOT_FOUND));
+		// TODO: Add approveApplication method to BadgeApply entity
+		// badgeApply.approveApplication();
+	}
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/badge/repository/BadgeApplyRepository.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/badge/repository/BadgeApplyRepository.java
@@ -1,0 +1,7 @@
+package laughcandidate.yellowribbonbe.badge.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import laughcandidate.yellowribbonbe.badge.entity.BadgeApply;
+
+public interface BadgeApplyRepository extends JpaRepository<BadgeApply, Long>, BadgeApplyRepositoryCustom {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/badge/repository/BadgeApplyRepositoryCustom.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/badge/repository/BadgeApplyRepositoryCustom.java
@@ -1,0 +1,17 @@
+package laughcandidate.yellowribbonbe.badge.repository;
+
+import laughcandidate.yellowribbonbe.badge.entity.BadgeApply;
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface BadgeApplyRepositoryCustom {
+    
+    Page<BadgeApply> findAllWithBasicInfo(Pageable pageable);
+    
+    Page<BadgeApply> findByStatusWithBasicInfo(Status status, Pageable pageable);
+    
+    Optional<BadgeApply> findByIdWithAllDetails(Long badgeApplyId);
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/badge/repository/BadgeApplyRepositoryImpl.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/badge/repository/BadgeApplyRepositoryImpl.java
@@ -1,0 +1,82 @@
+package laughcandidate.yellowribbonbe.badge.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import laughcandidate.yellowribbonbe.badge.entity.BadgeApply;
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static laughcandidate.yellowribbonbe.badge.entity.QBadgeApply.badgeApply;
+import static laughcandidate.yellowribbonbe.badge.entity.QBadge.badge;
+import static laughcandidate.yellowribbonbe.business.entity.QBusiness.business;
+import static laughcandidate.yellowribbonbe.user.entity.QUser.user;
+
+@RequiredArgsConstructor
+public class BadgeApplyRepositoryImpl implements BadgeApplyRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<BadgeApply> findAllWithBasicInfo(Pageable pageable) {
+        List<BadgeApply> content = queryFactory
+                .selectFrom(badgeApply)
+                .join(badgeApply.user, user).fetchJoin()
+                .join(badgeApply.badge, badge).fetchJoin()
+                // .join(badgeApply.business, business).fetchJoin()
+                .orderBy(badgeApply.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(badgeApply.count())
+                .from(badgeApply);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<BadgeApply> findByStatusWithBasicInfo(Status status, Pageable pageable) {
+        List<BadgeApply> content = queryFactory
+                .selectFrom(badgeApply)
+                .join(badgeApply.user, user).fetchJoin()
+                .join(badgeApply.badge, badge).fetchJoin()
+                // .join(badgeApply.business, business).fetchJoin()
+                .where(statusEq(status))
+                .orderBy(badgeApply.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(badgeApply.count())
+                .from(badgeApply)
+                .where(statusEq(status));
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Optional<BadgeApply> findByIdWithAllDetails(Long badgeApplyId) {
+        BadgeApply result = queryFactory
+                .selectFrom(badgeApply)
+                .join(badgeApply.user, user).fetchJoin()
+                .join(badgeApply.badge, badge).fetchJoin()
+                // .join(badgeApply.business, business).fetchJoin()
+                .where(badgeApply.id.eq(badgeApplyId))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    private BooleanExpression statusEq(Status status) {
+        return status != null ? badgeApply.status.eq(status) : null;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/AdminErrorCode.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/AdminErrorCode.java
@@ -1,0 +1,21 @@
+package laughcandidate.yellowribbonbe.global.exception.errorCode;
+
+import laughcandidate.yellowribbonbe.global.exception.errorCode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminErrorCode implements ErrorCode {
+    BADGE_APPLY_NOT_FOUND("ADMIN_001", "배지 신청을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return status;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/controller/MissionController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/controller/MissionController.java
@@ -1,8 +1,6 @@
 package laughcandidate.yellowribbonbe.mission.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,9 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import laughcandidate.yellowribbonbe.auth.service.CustomUserDetails;
 import laughcandidate.yellowribbonbe.global.response.ApiResponse;
-import laughcandidate.yellowribbonbe.mission.dto.response.MissionListResponse;
 import laughcandidate.yellowribbonbe.mission.dto.request.MissionValidationRequest;
 import laughcandidate.yellowribbonbe.mission.dto.response.MissionValidationResponse;
 import laughcandidate.yellowribbonbe.mission.service.MissionService;
@@ -39,18 +35,5 @@ public class MissionController {
 
 		MissionValidationResponse result = missionService.validateMission(missionId, request.image());
 		return ResponseEntity.ok(ApiResponse.ok(result));
-	}
-
-	@GetMapping("/list/{badgeId}")
-	@Operation(
-		summary = "사용자의 미션 현황 조회 API",
-		description = "사용자의 미션 현황을 조회합니다."
-	)
-	public ResponseEntity<ApiResponse<MissionListResponse>> getMissionList(
-		@PathVariable Long badgeId,
-		@AuthenticationPrincipal CustomUserDetails customUserDetails) {
-
-		MissionListResponse missionList = missionService.getMissionList(badgeId, customUserDetails.getBusinessId());
-		return ResponseEntity.ok(ApiResponse.ok(missionList));
 	}
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/repository/MissionRepository.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/repository/MissionRepository.java
@@ -3,8 +3,7 @@ package laughcandidate.yellowribbonbe.mission.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import laughcandidate.yellowribbonbe.mission.entity.Mission;
-import laughcandidate.yellowribbonbe.mission.repository.custom.MissionCustomRepository;
 
-public interface MissionRepository extends JpaRepository<Mission, Long>, MissionCustomRepository {
+public interface MissionRepository extends JpaRepository<Mission, Long> {
 
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/service/MissionService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/service/MissionService.java
@@ -1,17 +1,12 @@
 package laughcandidate.yellowribbonbe.mission.service;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import laughcandidate.yellowribbonbe.ai.enums.MissionResult;
 import laughcandidate.yellowribbonbe.ai.util.OpenAIUtil;
 import laughcandidate.yellowribbonbe.global.exception.CustomException;
 import laughcandidate.yellowribbonbe.global.exception.errorCode.MissionErrorCode;
-import laughcandidate.yellowribbonbe.mission.dto.response.MissionListResponse;
-import laughcandidate.yellowribbonbe.mission.dto.response.MissionInfoDto;
 import laughcandidate.yellowribbonbe.mission.dto.response.MissionValidationResponse;
 import laughcandidate.yellowribbonbe.mission.entity.Mission;
 import laughcandidate.yellowribbonbe.mission.repository.MissionRepository;
@@ -33,17 +28,6 @@ public class MissionService {
 		MissionResult missionResult = openAIUtil.sendPrompt(prompt, image);
 
 		return new MissionValidationResponse(missionResult);
-	}
-
-	@Transactional(readOnly = true)
-	public MissionListResponse getMissionList(Long badgeId, Long businessId) {
-		List<MissionInfoDto> result = missionRepository.findMissionWithSubmitData(badgeId, businessId);
-		
-		if (result.isEmpty()) {
-			throw new CustomException(MissionErrorCode.MISSION_NOT_FOUND);
-		}
-
-		return new MissionListResponse(result);
 	}
 
 	private String getPrompt(Mission mission) {

--- a/src/test/java/laughcandidate/yellowribbonbe/admin/controller/AdminBadgeControllerTest.java
+++ b/src/test/java/laughcandidate/yellowribbonbe/admin/controller/AdminBadgeControllerTest.java
@@ -1,0 +1,167 @@
+package laughcandidate.yellowribbonbe.admin.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import laughcandidate.yellowribbonbe.admin.dto.response.BadgeApplyListItemResponse;
+import laughcandidate.yellowribbonbe.admin.dto.response.BadgeApplyListResponse;
+import laughcandidate.yellowribbonbe.admin.service.AdminBadgeService;
+import laughcandidate.yellowribbonbe.badge.entity.BadgeApply;
+import laughcandidate.yellowribbonbe.badge.entity.Category;
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import laughcandidate.yellowribbonbe.global.exception.CustomException;
+import laughcandidate.yellowribbonbe.global.exception.errorCode.AdminErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@WebMvcTest(AdminBadgeController.class)
+class AdminBadgeControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private AdminBadgeService adminBadgeService;
+
+	@Test
+	@WithMockUser(authorities = "ROLE_ADMIN")
+	@DisplayName("관리자는 모든 배지 신청 목록을 조회할 수 있다")
+	void getAllBadgeApplies() throws Exception {
+		// given
+		BadgeApplyListItemResponse item = BadgeApplyListItemResponse.builder()
+			.badgeApplyId(1L)
+			.status(Status.PENDING)
+			.applicantName("홍길동")
+			.applicantPhone("010-1234-5678")
+			.businessName("테스트 카페")
+			.businessNo("123-45-67890")
+			.badgeCategory(Category.ENVIRONMENT_PROTECTION)
+			.appliedAt(LocalDateTime.now())
+			.build();
+
+		BadgeApplyListResponse response = BadgeApplyListResponse.builder()
+			.badgeApplies(List.of(item))
+			.currentPage(0)
+			.totalPages(1)
+			.totalElements(1L)
+			.size(20)
+			.hasNext(false)
+			.hasPrevious(false)
+			.build();
+
+		given(adminBadgeService.getBadgeApplies(eq(null), any(Pageable.class))).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/admin/badge/list")
+				.param("page", "0")
+				.param("size", "20"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(200))
+			.andExpect(jsonPath("$.message").value("OK"))
+			.andExpect(jsonPath("$.data.badgeApplies").isArray())
+			.andExpect(jsonPath("$.data.badgeApplies[0].badgeApplyId").value(1L))
+			.andExpect(jsonPath("$.data.badgeApplies[0].status").value("PENDING"))
+			.andExpect(jsonPath("$.data.badgeApplies[0].applicantName").value("홍길동"))
+			.andExpect(jsonPath("$.data.currentPage").value(0))
+			.andExpect(jsonPath("$.data.totalElements").value(1));
+	}
+
+	@Test
+	@WithMockUser(authorities = "ROLE_ADMIN")
+	@DisplayName("관리자는 상태별로 배지 신청 목록을 필터링할 수 있다")
+	void getBadgeAppliesByStatus() throws Exception {
+		// given
+		BadgeApplyListItemResponse item = BadgeApplyListItemResponse.builder()
+			.badgeApplyId(1L)
+			.status(Status.PENDING)
+			.applicantName("홍길동")
+			.applicantPhone("010-1234-5678")
+			.businessName("테스트 카페")
+			.businessNo("123-45-67890")
+			.badgeCategory(Category.ENVIRONMENT_PROTECTION)
+			.appliedAt(LocalDateTime.now())
+			.build();
+
+		BadgeApplyListResponse response = BadgeApplyListResponse.builder()
+			.badgeApplies(List.of(item))
+			.currentPage(0)
+			.totalPages(1)
+			.totalElements(1L)
+			.size(20)
+			.hasNext(false)
+			.hasPrevious(false)
+			.build();
+
+		given(adminBadgeService.getBadgeApplies(eq(Status.PENDING), any(Pageable.class)))
+			.willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/admin/badge/list")
+				.param("status", "PENDING")
+				.param("page", "0")
+				.param("size", "20"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(200))
+			.andExpect(jsonPath("$.message").value("OK"))
+			.andExpect(jsonPath("$.data.badgeApplies[0].status").value("PENDING"));
+	}
+
+	@Test
+	@WithMockUser(authorities = "ROLE_ADMIN")
+	@DisplayName("관리자는 특정 배지 신청의 상세 정보를 조회할 수 있다")
+	void getBadgeApplyDetail() throws Exception {
+		// given
+		BadgeApply badgeApply = mock(BadgeApply.class);
+		given(badgeApply.getId()).willReturn(1L);
+		given(badgeApply.getStatus()).willReturn(Status.PENDING);
+		given(adminBadgeService.getBadgeApplyDetail(1L)).willReturn(badgeApply);
+
+		// when & then
+		mockMvc.perform(get("/admin/badge/1"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(200))
+			.andExpect(jsonPath("$.message").value("OK"))
+			.andExpect(jsonPath("$.data.id").value(1L))
+			.andExpect(jsonPath("$.data.status").value("PENDING"));
+	}
+
+	@Test
+	@WithMockUser(authorities = "ROLE_ADMIN")
+	@DisplayName("존재하지 않는 배지 신청 조회 시 404 에러를 반환한다")
+	void getBadgeApplyDetail_NotFound() throws Exception {
+		// given
+		given(adminBadgeService.getBadgeApplyDetail(999L))
+			.willThrow(new
+				CustomException(AdminErrorCode.BADGE_APPLY_NOT_FOUND));
+
+		// when & then
+		mockMvc.perform(get("/admin/badge/999"))
+			.andDo(print())
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("신청 내역을 찾을 수 없습니다."))
+			.andExpect(jsonPath("$.code").value("P-001"));
+	}
+}

--- a/src/test/java/laughcandidate/yellowribbonbe/admin/service/AdminBadgeServiceTest.java
+++ b/src/test/java/laughcandidate/yellowribbonbe/admin/service/AdminBadgeServiceTest.java
@@ -1,0 +1,172 @@
+package laughcandidate.yellowribbonbe.admin.service;
+
+import laughcandidate.yellowribbonbe.admin.dto.response.BadgeApplyListResponse;
+import laughcandidate.yellowribbonbe.badge.entity.BadgeApply;
+import laughcandidate.yellowribbonbe.badge.entity.Badge;
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import laughcandidate.yellowribbonbe.badge.repository.BadgeApplyRepository;
+import laughcandidate.yellowribbonbe.business.entity.Business;
+import laughcandidate.yellowribbonbe.global.exception.CustomException;
+import laughcandidate.yellowribbonbe.global.exception.errorCode.AdminErrorCode;
+import laughcandidate.yellowribbonbe.user.entity.Role;
+import laughcandidate.yellowribbonbe.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class AdminBadgeServiceTest {
+
+	@InjectMocks
+	private AdminBadgeService adminBadgeService;
+
+	@Mock
+	private BadgeApplyRepository badgeApplyRepository;
+
+	@Test
+	@DisplayName("모든 배지 신청 목록을 페이지네이션으로 조회한다")
+	void getAllBadgeApplies() {
+		// given
+		Pageable pageable = PageRequest.of(0, 20);
+		List<BadgeApply> badgeApplies = List.of(createMockBadgeApply());
+		Page<BadgeApply> page = new PageImpl<>(badgeApplies, pageable, 1);
+		given(badgeApplyRepository.findAllWithBasicInfo(pageable)).willReturn(page);
+
+		// when
+		BadgeApplyListResponse result = adminBadgeService.getAllBadgeApplies(pageable);
+
+		// then
+		assertThat(result.badgeApplies()).hasSize(1);
+		assertThat(result.totalElements()).isEqualTo(1);
+		assertThat(result.currentPage()).isEqualTo(0);
+		verify(badgeApplyRepository).findAllWithBasicInfo(pageable);
+	}
+
+	@Test
+	@DisplayName("상태별 배지 신청 목록을 페이지네이션으로 조회한다")
+	void getBadgeAppliesByStatus() {
+		// given
+		Status status = Status.PENDING;
+		Pageable pageable = PageRequest.of(0, 20);
+		List<BadgeApply> badgeApplies = List.of(createMockBadgeApply());
+		Page<BadgeApply> page = new PageImpl<>(badgeApplies, pageable, 1);
+		given(badgeApplyRepository.findByStatusWithBasicInfo(eq(status), eq(pageable))).willReturn(page);
+
+		// when
+		BadgeApplyListResponse result = adminBadgeService.getBadgeAppliesByStatus(status, pageable);
+
+		// then
+		assertThat(result.badgeApplies()).hasSize(1);
+		assertThat(result.badgeApplies().get(0).status()).isEqualTo(Status.PENDING);
+		verify(badgeApplyRepository).findByStatusWithBasicInfo(status, pageable);
+	}
+
+	@Test
+	@DisplayName("배지 신청 상세 정보를 조회한다")
+	void getBadgeApplyDetail() {
+		// given
+		Long badgeApplyId = 1L;
+		BadgeApply badgeApply = createMockBadgeApply();
+		given(badgeApplyRepository.findByIdWithAllDetails(badgeApplyId)).willReturn(Optional.of(badgeApply));
+
+		// when
+		BadgeApply result = adminBadgeService.getBadgeApplyDetail(badgeApplyId);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getStatus()).isEqualTo(Status.PENDING);
+		verify(badgeApplyRepository).findByIdWithAllDetails(badgeApplyId);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 배지 신청 조회 시 예외를 발생시킨다")
+	void getBadgeApplyDetail_NotFound() {
+		// given
+		Long badgeApplyId = 999L;
+		given(badgeApplyRepository.findByIdWithAllDetails(badgeApplyId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> adminBadgeService.getBadgeApplyDetail(badgeApplyId))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", AdminErrorCode.BADGE_APPLY_NOT_FOUND);
+
+		verify(badgeApplyRepository).findByIdWithAllDetails(badgeApplyId);
+	}
+
+	@Test
+	@DisplayName("배지 신청을 승인한다")
+	void approveBadgeApplication() {
+		// given
+		Long badgeApplyId = 1L;
+		BadgeApply badgeApply = createMockBadgeApply();
+		given(badgeApplyRepository.findById(badgeApplyId)).willReturn(Optional.of(badgeApply));
+
+		// when
+		adminBadgeService.approveBadgeApplication(badgeApplyId);
+
+		// then
+		assertThat(badgeApply.getStatus()).isEqualTo(Status.COMPLETE);
+		verify(badgeApplyRepository).findById(badgeApplyId);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 배지 신청 승인 시 예외를 발생시킨다")
+	void approveBadgeApplication_NotFound() {
+		// given
+		Long badgeApplyId = 999L;
+		given(badgeApplyRepository.findById(badgeApplyId)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> adminBadgeService.approveBadgeApplication(badgeApplyId))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", AdminErrorCode.BADGE_APPLY_NOT_FOUND);
+
+		verify(badgeApplyRepository).findById(badgeApplyId);
+	}
+
+	private BadgeApply createMockBadgeApply() {
+		User user = User.builder()
+			.name("홍길동")
+			.phone("010-1234-1234")
+			.loginId("testuser")
+			.password("password")
+			.uid("test_uid")
+			.role(Role.ROLE_USER)
+			.build();
+
+		Business business = Business.builder()
+			.businessName("테스트 카페")
+			.businessNo("123-45-67890")
+			.ownerName("홍길동")
+			.startDate(LocalDate.now())
+			.user(user)
+			.build();
+
+		Badge badge = mock(Badge.class);
+
+		return BadgeApply.builder()
+			.user(user)
+			.business(business)
+			.badge(badge)
+			.status(Status.PENDING)
+			.build();
+	}
+}

--- a/src/test/java/laughcandidate/yellowribbonbe/badge/repository/BadgeApplyRepositoryTest.java
+++ b/src/test/java/laughcandidate/yellowribbonbe/badge/repository/BadgeApplyRepositoryTest.java
@@ -1,0 +1,202 @@
+package laughcandidate.yellowribbonbe.badge.repository;
+
+import laughcandidate.yellowribbonbe.badge.entity.BadgeApply;
+import laughcandidate.yellowribbonbe.badge.entity.Badge;
+import laughcandidate.yellowribbonbe.badge.entity.Category;
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import laughcandidate.yellowribbonbe.business.entity.Business;
+import laughcandidate.yellowribbonbe.business.repository.BusinessRepository;
+import laughcandidate.yellowribbonbe.user.entity.Role;
+import laughcandidate.yellowribbonbe.user.entity.User;
+import laughcandidate.yellowribbonbe.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.context.annotation.Import;
+import laughcandidate.yellowribbonbe.global.config.QueryDslConfig;
+import java.lang.reflect.Constructor;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@EnableJpaAuditing
+@Import(QueryDslConfig.class)
+class BadgeApplyRepositoryTest {
+
+	@Autowired
+	private TestEntityManager entityManager;
+
+	@Autowired
+	private BadgeApplyRepository badgeApplyRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private BusinessRepository businessRepository;
+
+	private User testUser;
+	private Business testBusiness;
+	private Badge testBadge;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		testUser = User.builder()
+			.name("홍길동")
+			.loginId("testuser")
+			.password("password123")
+			.phone("010-1234-5678")
+			.uid("test-uid")
+			.role(Role.ROLE_USER)
+			.build();
+		entityManager.persistAndFlush(testUser);
+
+		testBusiness = Business.builder()
+			.businessName("테스트 카페")
+			.businessNo("123-45-67890")
+			.ownerName("홍길동")
+			.startDate(LocalDate.now())
+			.user(testUser)
+			.build();
+		entityManager.persistAndFlush(testBusiness);
+
+		Constructor<Badge> constructor = Badge.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		testBadge = constructor.newInstance();
+		ReflectionTestUtils.setField(testBadge, "category", Category.ENVIRONMENT_PROTECTION);
+		entityManager.persist(testBadge);
+		entityManager.flush();
+	}
+
+	@Test
+	@DisplayName("모든 배지 신청을 최신순으로 페이지네이션 조회한다")
+	void findAllWithBasicInfo() {
+		// given
+		BadgeApply badgeApply1 = createBadgeApply(Status.PENDING);
+		BadgeApply badgeApply2 = createBadgeApply(Status.COMPLETE);
+		BadgeApply badgeApply3 = createBadgeApply(Status.REJECTED);
+
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// when
+		Page<BadgeApply> result = badgeApplyRepository.findAllWithBasicInfo(pageable);
+
+		// then
+		assertThat(result.getContent()).hasSize(3);
+		assertThat(result.getTotalElements()).isEqualTo(3);
+		assertThat(result.getNumber()).isEqualTo(0);
+		assertThat(result.getSize()).isEqualTo(10);
+
+		BadgeApply firstApply = result.getContent().get(0);
+		assertThat(firstApply.getUser()).isNotNull();
+		assertThat(firstApply.getBadge()).isNotNull();
+		assertThat(firstApply.getBusiness()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("특정 상태의 배지 신청을 페이지네이션으로 조회한다")
+	void findByStatusWithBasicInfo() {
+		// given
+		createBadgeApply(Status.PENDING);
+		createBadgeApply(Status.PENDING);
+		createBadgeApply(Status.COMPLETE);
+
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// when
+		Page<BadgeApply> result = badgeApplyRepository.findByStatusWithBasicInfo(Status.PENDING, pageable);
+
+		// then
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getTotalElements()).isEqualTo(2);
+
+		assertThat(result.getContent())
+			.allMatch(apply -> apply.getStatus() == Status.PENDING);
+	}
+
+	@Test
+	@DisplayName("ID로 배지 신청 상세 정보를 조회한다")
+	void findByIdWithAllDetails() {
+		// given
+		BadgeApply savedApply = createBadgeApply(Status.PENDING);
+
+		// when
+		Optional<BadgeApply> result = badgeApplyRepository.findByIdWithAllDetails(savedApply.getId());
+
+		// then
+		assertThat(result).isPresent();
+		BadgeApply foundApply = result.get();
+		assertThat(foundApply.getId()).isEqualTo(savedApply.getId());
+		assertThat(foundApply.getStatus()).isEqualTo(Status.PENDING);
+		assertThat(foundApply.getUser()).isNotNull();
+		assertThat(foundApply.getUser().getName()).isEqualTo("홍길동");
+		assertThat(foundApply.getBusiness()).isNotNull();
+		assertThat(foundApply.getBusiness().getBusinessName()).isEqualTo("테스트 카페");
+		assertThat(foundApply.getBadge()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 ID로 조회하면 빈 Optional을 반환한다")
+	void findByIdWithAllDetails_NotFound() {
+		// when
+		Optional<BadgeApply> result = badgeApplyRepository.findByIdWithAllDetails(999L);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("페이지네이션이 정확히 동작한다")
+	void paginationTest() {
+		// given
+		for (int i = 0; i < 25; i++) {
+			createBadgeApply(Status.PENDING);
+		}
+
+		Pageable firstPage = PageRequest.of(0, 10);
+		Pageable secondPage = PageRequest.of(1, 10);
+		Pageable thirdPage = PageRequest.of(2, 10);
+
+		// when
+		Page<BadgeApply> page1 = badgeApplyRepository.findAllWithBasicInfo(firstPage);
+		Page<BadgeApply> page2 = badgeApplyRepository.findAllWithBasicInfo(secondPage);
+		Page<BadgeApply> page3 = badgeApplyRepository.findAllWithBasicInfo(thirdPage);
+
+		// then
+		assertThat(page1.getContent()).hasSize(10);
+		assertThat(page1.getTotalPages()).isEqualTo(3);
+		assertThat(page1.hasNext()).isTrue();
+		assertThat(page1.hasPrevious()).isFalse();
+
+		assertThat(page2.getContent()).hasSize(10);
+		assertThat(page2.hasNext()).isTrue();
+		assertThat(page2.hasPrevious()).isTrue();
+
+		assertThat(page3.getContent()).hasSize(5);
+		assertThat(page3.hasNext()).isFalse();
+		assertThat(page3.hasPrevious()).isTrue();
+	}
+
+	private BadgeApply createBadgeApply(Status status) {
+		BadgeApply badgeApply = BadgeApply.builder()
+			.user(testUser)
+			.business(testBusiness)
+			.badge(testBadge)
+			.status(status)
+			.build();
+
+		return entityManager.persistAndFlush(badgeApply);
+	}
+}


### PR DESCRIPTION
## 📄 PR 내용

<!--- 작업에 대한 요약 설명을 작성해 주세요. -->

- 관리자가 배지 신청을 관리하고 리본 발급 내역을 조회할 수 있는 API를 구현했습니다.

## 📝 수정 상세 내용

<!--- 작업 전과 후의 변화를 설명해 주세요. -->

### 배지 관리
  - 배지 신청 목록 조회 (페이지네이션, 상태별 필터링)
  - 배지 신청 상세 조회 (미션 정보는 추후 추가 예정)
  - 배지 발급

  ### 리본 관리
  - 리본 발급 내역 조회 (사업체명, 발급일자)

  ### API 엔드포인트
  - `GET /admin/badge/list` - 배지 신청 목록
  - `GET /admin/badge/{badgeApplyId}` - 배지 신청 상세
  - `POST /admin/badge/{badgeApplyId}/approve` - 배지 승인
  - `GET /admin/ribbon/list` - 리본 발급 내역

  ### 주요 변경사항
  - BadgeApply 엔티티에 Builder 패턴 및 상태 변경 메서드 추가
  - BadgeApply 엔티티에 business_id 추가
  - Badge 엔티티 컬럼명 오타 수정 (bagde_id → badge_id)
  - JOIN FETCH 쿼리로 N+1 문제 방지

## 📍 레퍼런스
- X