### PR TITLE
[FEAT] 특정 뱃지에서 현재 사업자의 미션 달성 현황 리스트들 반환

### DIFF
--- a/src/main/java/laughcandidate/yellowribbonbe/badge/entity/BadgeApply.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/badge/entity/BadgeApply.java
@@ -2,6 +2,7 @@ package laughcandidate.yellowribbonbe.badge.entity;
 
 import jakarta.persistence.*;
 import laughcandidate.yellowribbonbe.global.entity.BaseEntity;
+import laughcandidate.yellowribbonbe.global.entity.Status;
 import laughcandidate.yellowribbonbe.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/laughcandidate/yellowribbonbe/business/controller/BusinessController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/controller/BusinessController.java
@@ -1,7 +1,5 @@
 package laughcandidate.yellowribbonbe.business.controller;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,7 +14,6 @@ import jakarta.validation.Valid;
 import laughcandidate.yellowribbonbe.auth.service.CustomUserDetails;
 import laughcandidate.yellowribbonbe.business.dto.request.ConnectOptionalRequest;
 import laughcandidate.yellowribbonbe.business.dto.request.ConnectRequiredRequest;
-import laughcandidate.yellowribbonbe.business.dto.response.BusinessInfoResponse;
 import laughcandidate.yellowribbonbe.business.dto.response.BusinessInfoListResponse;
 import laughcandidate.yellowribbonbe.business.dto.response.ConnectResponse;
 import laughcandidate.yellowribbonbe.business.service.BusinessService;

--- a/src/main/java/laughcandidate/yellowribbonbe/business/entity/Business.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/business/entity/Business.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import laughcandidate.yellowribbonbe.global.entity.BaseEntity;
 import laughcandidate.yellowribbonbe.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "BUSINESS")
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Business {
+public class Business extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/laughcandidate/yellowribbonbe/global/entity/Status.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/entity/Status.java
@@ -1,4 +1,4 @@
-package laughcandidate.yellowribbonbe.badge.entity;
+package laughcandidate.yellowribbonbe.global.entity;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/laughcandidate/yellowribbonbe/image/entity/Image.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/image/entity/Image.java
@@ -1,0 +1,39 @@
+package laughcandidate.yellowribbonbe.image.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import laughcandidate.yellowribbonbe.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Table(name = "IMAGE")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "mission_id")
+	private Long id;
+
+	@Column(name = "key", unique = true)
+	private String key;
+
+	@Column(name = "original_name")
+	private String originalName;
+
+	@Column(name = "size")
+	private Integer size;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "type")
+	private ImageType type;
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/image/entity/ImageType.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/image/entity/ImageType.java
@@ -1,0 +1,18 @@
+package laughcandidate.yellowribbonbe.image.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageType {
+	JPEG("image/jpeg"),
+	JPG("image/jpg"),
+	PNG("image/png"),
+	GIF("image/gif"),
+	WEBP("image/webp"),
+	BMP("image/bmp"),
+	SVG("image/svg+xml");
+
+	private final String type;
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/controller/MissionController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/controller/MissionController.java
@@ -1,6 +1,8 @@
 package laughcandidate.yellowribbonbe.mission.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,7 +12,9 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import laughcandidate.yellowribbonbe.auth.service.CustomUserDetails;
 import laughcandidate.yellowribbonbe.global.response.ApiResponse;
+import laughcandidate.yellowribbonbe.mission.dto.response.MissionListResponse;
 import laughcandidate.yellowribbonbe.mission.dto.request.MissionValidationRequest;
 import laughcandidate.yellowribbonbe.mission.dto.response.MissionValidationResponse;
 import laughcandidate.yellowribbonbe.mission.service.MissionService;
@@ -35,5 +39,18 @@ public class MissionController {
 
 		MissionValidationResponse result = missionService.validateMission(missionId, request.image());
 		return ResponseEntity.ok(ApiResponse.ok(result));
+	}
+
+	@GetMapping("/list/{badgeId}")
+	@Operation(
+		summary = "사용자의 미션 현황 조회 API",
+		description = "사용자의 미션 현황을 조회합니다."
+	)
+	public ResponseEntity<ApiResponse<MissionListResponse>> getMissionList(
+		@PathVariable Long badgeId,
+		@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+		MissionListResponse missionList = missionService.getMissionList(badgeId, customUserDetails.getBusinessId());
+		return ResponseEntity.ok(ApiResponse.ok(missionList));
 	}
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/dto/response/MissionInfoDto.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/dto/response/MissionInfoDto.java
@@ -1,0 +1,23 @@
+package laughcandidate.yellowribbonbe.mission.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import laughcandidate.yellowribbonbe.badge.entity.Category;
+
+@Schema(description = "미션 정보")
+public record MissionInfoDto(
+    @Schema(description = "거절 사유")
+    String reason,
+    
+    @Schema(description = "미션 상태")
+    Status status,
+    
+    @Schema(description = "미션 설명")
+    String description,
+    
+    @Schema(description = "미션 ID")
+    Long missionId,
+    
+    @Schema(description = "배지 카테고리")
+    Category category
+) {}

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/dto/response/MissionListResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/dto/response/MissionListResponse.java
@@ -1,0 +1,6 @@
+package laughcandidate.yellowribbonbe.mission.dto.response;
+
+import java.util.List;
+
+public record MissionListResponse(List<MissionInfoDto> missions) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/entity/Mission.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/entity/Mission.java
@@ -2,10 +2,15 @@ package laughcandidate.yellowribbonbe.mission.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import laughcandidate.yellowribbonbe.badge.entity.Badge;
+import laughcandidate.yellowribbonbe.global.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "MISSION")
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Mission {
+public class Mission extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,4 +31,8 @@ public class Mission {
 
 	@Column(name = "description")
 	private String description;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "badge_id", nullable = false)
+	private Badge badge;
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/entity/MissionSubmit.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/entity/MissionSubmit.java
@@ -1,0 +1,51 @@
+package laughcandidate.yellowribbonbe.mission.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import laughcandidate.yellowribbonbe.global.entity.BaseEntity;
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import laughcandidate.yellowribbonbe.image.entity.Image;
+import laughcandidate.yellowribbonbe.business.entity.Business;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Table(name = "MISSION_SUBMIT")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MissionSubmit extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "mission_submit_id")
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status")
+	private Status status;
+
+	@Column(name = "reason")
+	private String reason;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "mission_id", nullable = false)
+	private Mission mission;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "image_id", nullable = false)
+	private Image image;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "business_id", nullable = false)
+	private Business business;
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/repository/MissionRepository.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/repository/MissionRepository.java
@@ -3,7 +3,8 @@ package laughcandidate.yellowribbonbe.mission.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import laughcandidate.yellowribbonbe.mission.entity.Mission;
+import laughcandidate.yellowribbonbe.mission.repository.custom.MissionCustomRepository;
 
-public interface MissionRepository extends JpaRepository<Mission, Long> {
+public interface MissionRepository extends JpaRepository<Mission, Long>, MissionCustomRepository {
 
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/repository/custom/MissionCustomRepository.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/repository/custom/MissionCustomRepository.java
@@ -1,0 +1,9 @@
+package laughcandidate.yellowribbonbe.mission.repository.custom;
+
+import laughcandidate.yellowribbonbe.mission.dto.response.MissionInfoDto;
+import java.util.List;
+
+public interface MissionCustomRepository {
+    
+    List<MissionInfoDto> findMissionWithSubmitData(Long badgeId, Long businessId);
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/repository/custom/MissionCustomRepositoryImpl.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/repository/custom/MissionCustomRepositoryImpl.java
@@ -1,0 +1,41 @@
+package laughcandidate.yellowribbonbe.mission.repository.custom;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import laughcandidate.yellowribbonbe.mission.dto.response.MissionInfoDto;
+import laughcandidate.yellowribbonbe.mission.entity.QMission;
+import laughcandidate.yellowribbonbe.mission.entity.QMissionSubmit;
+import laughcandidate.yellowribbonbe.badge.entity.QBadge;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MissionCustomRepositoryImpl implements MissionCustomRepository {
+    
+    private final JPAQueryFactory queryFactory;
+    
+    @Override
+    public List<MissionInfoDto> findMissionWithSubmitData(Long badgeId, Long businessId) {
+        QMissionSubmit missionSubmit = QMissionSubmit.missionSubmit;
+        QMission mission = QMission.mission;
+        QBadge badge = QBadge.badge;
+        
+        return queryFactory
+                .select(Projections.constructor(MissionInfoDto.class,
+                        missionSubmit.reason,
+                        missionSubmit.status,
+                        mission.description,
+                        mission.id,
+                        badge.category
+                ))
+                .from(missionSubmit)
+                .join(missionSubmit.mission, mission)
+                .join(mission.badge, badge)
+.where(badge.id.eq(badgeId)
+                        .and(missionSubmit.business.id.eq(businessId)))
+                .fetch();
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/service/MissionService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/service/MissionService.java
@@ -1,12 +1,17 @@
 package laughcandidate.yellowribbonbe.mission.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import laughcandidate.yellowribbonbe.ai.enums.MissionResult;
 import laughcandidate.yellowribbonbe.ai.util.OpenAIUtil;
 import laughcandidate.yellowribbonbe.global.exception.CustomException;
 import laughcandidate.yellowribbonbe.global.exception.errorCode.MissionErrorCode;
+import laughcandidate.yellowribbonbe.mission.dto.response.MissionListResponse;
+import laughcandidate.yellowribbonbe.mission.dto.response.MissionInfoDto;
 import laughcandidate.yellowribbonbe.mission.dto.response.MissionValidationResponse;
 import laughcandidate.yellowribbonbe.mission.entity.Mission;
 import laughcandidate.yellowribbonbe.mission.repository.MissionRepository;
@@ -28,6 +33,17 @@ public class MissionService {
 		MissionResult missionResult = openAIUtil.sendPrompt(prompt, image);
 
 		return new MissionValidationResponse(missionResult);
+	}
+
+	@Transactional(readOnly = true)
+	public MissionListResponse getMissionList(Long badgeId, Long businessId) {
+		List<MissionInfoDto> result = missionRepository.findMissionWithSubmitData(badgeId, businessId);
+		
+		if (result.isEmpty()) {
+			throw new CustomException(MissionErrorCode.MISSION_NOT_FOUND);
+		}
+
+		return new MissionListResponse(result);
 	}
 
 	private String getPrompt(Mission mission) {


### PR DESCRIPTION
## 📄 PR 내용

- 뱃지 id, 사업자 id를 통해 현재 미션의 진행 상황 반환

## 📝 수정 상세 내용

- badgeId, jwt 토큰의 businessId를 통해서 Badge, MissionSubmit, Mission, Business 테이블 4개를 join하여 미션 진행 상황 반환

## ✅ 체크리스트

- [X] badgeId, jwt 토큰의 businessId를 통해서 Badge, MissionSubmit, Mission, Business 테이블 4개를 join하여 미션 진행 상황 반환


## 📍 레퍼런스

- X