### PR TITLE
[FIX] 옐로 리본 혜택 테이블 분리에 따른 엔티티 수정

### DIFF
--- a/src/main/java/laughcandidate/yellowribbonbe/yellowRibbon/entity/YellowRibbon.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/yellowRibbon/entity/YellowRibbon.java
@@ -17,9 +17,6 @@ public class YellowRibbon extends BaseEntity {
     @Column(name = "yellow_ribbon_id")
     private Long id;
 
-    @Column(name = "benefit")
-    private String benefit;
-
     @Column(name = "season")
     private Integer season;
 

--- a/src/main/java/laughcandidate/yellowribbonbe/yellowRibbon/entity/YellowRibbonBenefit.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/yellowRibbon/entity/YellowRibbonBenefit.java
@@ -1,0 +1,33 @@
+package laughcandidate.yellowribbonbe.yellowRibbon.entity;
+
+import jakarta.persistence.*;
+import laughcandidate.yellowribbonbe.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "YELLOW_RIBBON_BENEFIT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class YellowRibbonBenefit extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "yellow_ribbon_benefit_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "yellow_ribbon_id", nullable = false)
+    private YellowRibbon yellowRibbon;
+
+    @Column(name = "name", length = 255, nullable = false)
+    private String name;
+
+    @Column(name = "description", length = 255)
+    private String description;
+
+    @Column(name = "link_url", length = 255)
+    private String linkUrl;
+
+}


### PR DESCRIPTION
## 📄 PR 내용
이슈 번호 : #38 
기존에 옐로 리본 테이블에 혜택이 컬럼으로 저장되어 있던 것에서
혜택 테이블을 분리하는 것으로 엔티티 수정

## 📝 상세 내용
YellowRibbon 엔티티에서 benefit 컬럼 제거
YellowRibbonBenefit 엔티티 생성 및 테이블에 혜택 정보 추가

## ✅ 체크리스트

- [x] YellowRibbon 엔티티에서 benefit 컬럼 제거
- [x] YellowRibbonBenefit 엔티티 생성 및 테이블에 혜택 정보 추가

## 📍 레퍼런스
X