### PR TITLE
[FEAT] 관리자 미션 상태 변경 API 구현

### DIFF
--- a/src/main/java/laughcandidate/yellowribbonbe/admin/controller/AdminMissionController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/admin/controller/AdminMissionController.java
@@ -1,0 +1,41 @@
+package laughcandidate.yellowribbonbe.admin.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import laughcandidate.yellowribbonbe.admin.dto.request.MissionStatusUpdateRequest;
+import laughcandidate.yellowribbonbe.admin.service.AdminMissionService;
+import laughcandidate.yellowribbonbe.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "관리자 - 미션 관리")
+@RestController
+@RequestMapping("/admin/mission")
+@RequiredArgsConstructor
+public class AdminMissionController {
+
+    private final AdminMissionService adminMissionService;
+
+    @PutMapping("/{missionSubmitId}/status")
+    @Operation(
+        summary = "미션 상태 변경 API",
+        description = "관리자가 미션 제출의 상태를 변경합니다. ")
+    public ResponseEntity<ApiResponse<Void>> updateMissionStatus(
+        @Parameter(description = "미션 제출 ID")
+        @PathVariable Long missionSubmitId,
+        
+        @Parameter(description = "상태 변경 요청 정보")
+        @Valid @RequestBody MissionStatusUpdateRequest request
+    ) {
+        adminMissionService.updateMissionStatus(missionSubmitId, request);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/admin/controller/AdminMissionController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/admin/controller/AdminMissionController.java
@@ -1,8 +1,8 @@
 package laughcandidate.yellowribbonbe.admin.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,7 +24,7 @@ public class AdminMissionController {
 
     private final AdminMissionService adminMissionService;
 
-    @PutMapping("/{missionSubmitId}/status")
+    @PatchMapping("/{missionSubmitId}/status")
     @Operation(
         summary = "미션 상태 변경 API",
         description = "관리자가 미션 제출의 상태를 변경합니다. ")

--- a/src/main/java/laughcandidate/yellowribbonbe/admin/dto/request/MissionStatusUpdateRequest.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/admin/dto/request/MissionStatusUpdateRequest.java
@@ -1,0 +1,15 @@
+package laughcandidate.yellowribbonbe.admin.dto.request;
+
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import lombok.Builder;
+
+import jakarta.validation.constraints.NotNull;
+
+@Builder
+public record MissionStatusUpdateRequest(
+        @NotNull(message = "상태는 필수입니다")
+        Status status,
+        
+        String reason
+) {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/admin/service/AdminMissionService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/admin/service/AdminMissionService.java
@@ -1,0 +1,57 @@
+package laughcandidate.yellowribbonbe.admin.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import laughcandidate.yellowribbonbe.admin.dto.request.MissionStatusUpdateRequest;
+import laughcandidate.yellowribbonbe.global.entity.Status;
+import laughcandidate.yellowribbonbe.global.exception.CustomException;
+import laughcandidate.yellowribbonbe.global.exception.errorCode.AdminErrorCode;
+import laughcandidate.yellowribbonbe.mission.entity.MissionSubmit;
+import laughcandidate.yellowribbonbe.mission.repository.MissionSubmitRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMissionService {
+
+    private final MissionSubmitRepository missionSubmitRepository;
+
+    @Transactional
+    public void updateMissionStatus(Long missionSubmitId, MissionStatusUpdateRequest request) {
+        MissionSubmit missionSubmit = missionSubmitRepository.findById(missionSubmitId)
+            .orElseThrow(() -> new CustomException(AdminErrorCode.MISSION_SUBMIT_NOT_FOUND));
+
+        validateStatusTransition(missionSubmit.getStatus(), request.status());
+
+        missionSubmit.updateStatus(request.status());
+        
+        if (request.reason() != null) {
+            missionSubmit.updateReason(request.reason());
+        }
+    }
+
+    private void validateStatusTransition(Status currentStatus, Status newStatus) {
+        if (currentStatus == newStatus) {
+            throw new CustomException(AdminErrorCode.INVALID_STATUS_TRANSITION);
+        }
+
+        switch (currentStatus) {
+            case PENDING -> {
+                if (newStatus != Status.COMPLETE && newStatus != Status.REJECTED) {
+                    throw new CustomException(AdminErrorCode.INVALID_STATUS_TRANSITION);
+                }
+            }
+            case COMPLETE -> {
+                if (newStatus != Status.REJECTED) {
+                    throw new CustomException(AdminErrorCode.INVALID_STATUS_TRANSITION);
+                }
+            }
+            case REJECTED -> {
+                if (newStatus != Status.PENDING) {
+                    throw new CustomException(AdminErrorCode.INVALID_STATUS_TRANSITION);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/AdminErrorCode.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/AdminErrorCode.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 public enum AdminErrorCode implements ErrorCode {
 
     BADGE_APPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "A001", "배지 신청을 찾을 수 없습니다."),
-    YELLOW_RIBBON_NOT_FOUND(HttpStatus.NOT_FOUND, "A002", "현재 발급 가능한 리본을 찾을 수 없습니다.");
+    YELLOW_RIBBON_NOT_FOUND(HttpStatus.NOT_FOUND, "A002", "현재 발급 가능한 리본을 찾을 수 없습니다."),
+    MISSION_SUBMIT_NOT_FOUND(HttpStatus.NOT_FOUND, "A003", "미션 제출을 찾을 수 없습니다."),
+    INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "A004", "유효하지 않은 상태 전환입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/laughcandidate/yellowribbonbe/mission/entity/MissionSubmit.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mission/entity/MissionSubmit.java
@@ -57,4 +57,8 @@ public class MissionSubmit extends BaseEntity {
 	public void updateStatus(Status status) {
 		this.status = status;
 	}
+	
+	public void updateReason(String reason) {
+		this.reason = reason;
+	}
 }


### PR DESCRIPTION
## 📄 PR 내용

<!--- 작업에 대한 요약 설명을 작성해 주세요. -->

- 관리자가 미션 제출의 상태를 변경할 수 있는 API를 구현했습니다. 상태 전환 규칙을 검증하고 사유를 함께 업데이트할 수 있도록 구성했습니다.

## 📝 수정 상세 내용

<!--- 작업 전과 후의 변화를 설명해 주세요. -->




  📝 주요 변경사항

  1. 새로운 API 엔드포인트

  - `PATCH /admin/mission/{missionSubmitId}/status`: 미션 상태 변경 API
  - 요청 Body: 변경할 상태와 사유 포함

  2. 상태 전환 규칙 구현

  - PENDING → COMPLETE: 인증 성공 후 완료 처리
  - PENDING → REJECTED: 인증 거절
  - COMPLETE → REJECTED: 재인증 요청
  - REJECTED → PENDING: 재인증으로 되돌리기

  3. 새로운 컴포넌트

  - `MissionStatusUpdateRequest`: 상태 변경 요청 DTO
  - `AdminMissionService`: 상태 전환 유효성 검증 및 업데이트 로직
  - `AdminMissionController`: REST API 엔드포인트 제공

  4. 엔티티 및 에러 처리 개선

  - `MissionSubmit.updateReason()`: 사유 업데이트 메서드 추가
  - `AdminErrorCode`: 미션 관련 에러 코드 추가

  📋 API 사용 예시

  요청:
  `PATCH /admin/mission/123/status`
  `Content-Type: application/json`
```
  {
    "status": "COMPLETE",
    "reason": "인증 완료"
  }
```
  응답:
```
  {
    "code": "S001",
    "message": "성공",
    "data": null
  }
```
## ✅ 체크리스트

- [x] 미션 상태 변경 API 구현

## 📍 레퍼런스

- x