### PR TITLE
[FEAT] 유저가 이용 중인 혜택상품 리스트 조회

### DIFF
--- a/src/main/java/laughcandidate/yellowribbonbe/product/controller/ProductController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/product/controller/ProductController.java
@@ -6,6 +6,7 @@ import laughcandidate.yellowribbonbe.auth.service.CustomUserDetails;
 import laughcandidate.yellowribbonbe.global.response.ApiResponse;
 import laughcandidate.yellowribbonbe.product.dto.ProductDetailResponse;
 import laughcandidate.yellowribbonbe.product.dto.ProductListResponse;
+import laughcandidate.yellowribbonbe.product.dto.UserBenefitProductResponse;
 import laughcandidate.yellowribbonbe.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -46,5 +47,17 @@ public class ProductController {
         
         ProductDetailResponse productDetail = productService.getProductDetail(productId);
         return ResponseEntity.ok(ApiResponse.ok(productDetail));
+    }
+
+    @GetMapping("/my-benefits")
+    @Operation(
+        summary = "나의 보유 혜택 상품 조회 API",
+        description = "현재 로그인한 사용자가 보유한 혜택 상품 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<UserBenefitProductResponse>>> getMyBenefitProducts(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        
+        List<UserBenefitProductResponse> myBenefitProducts = 
+                productService.getMyBenefitProducts(customUserDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.ok(myBenefitProducts));
     }
 }

--- a/src/main/java/laughcandidate/yellowribbonbe/product/dto/UserBenefitProductResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/product/dto/UserBenefitProductResponse.java
@@ -1,0 +1,23 @@
+package laughcandidate.yellowribbonbe.product.dto;
+
+import laughcandidate.yellowribbonbe.product.entity.UserBenefitProduct;
+
+import java.time.LocalDateTime;
+
+public record UserBenefitProductResponse(
+        Long productId,
+        String productName,
+        String description,
+        String category,
+        LocalDateTime subscribedAt
+) {
+    public static UserBenefitProductResponse from(UserBenefitProduct userBenefitProduct) {
+        return new UserBenefitProductResponse(
+                userBenefitProduct.getProduct().getId(),
+                userBenefitProduct.getProduct().getName(),
+                userBenefitProduct.getProduct().getDescription(),
+                userBenefitProduct.getProduct().getCategory().getDescription(),
+                userBenefitProduct.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/product/entity/UserBenefitProduct.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/product/entity/UserBenefitProduct.java
@@ -1,0 +1,47 @@
+package laughcandidate.yellowribbonbe.product.entity;
+
+import jakarta.persistence.*;
+import laughcandidate.yellowribbonbe.global.entity.BaseEntity;
+import laughcandidate.yellowribbonbe.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "USER_BENEFIT_PRODUCTS")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserBenefitProduct extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_benefit_product_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Column(name = "is_active")
+    private boolean isActive = true;
+
+    @Builder
+    public UserBenefitProduct(User user, Product product) {
+        this.user = user;
+        this.product = product;
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/product/repository/UserBenefitProductRepository.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/product/repository/UserBenefitProductRepository.java
@@ -1,0 +1,10 @@
+package laughcandidate.yellowribbonbe.product.repository;
+
+import laughcandidate.yellowribbonbe.product.entity.UserBenefitProduct;
+import laughcandidate.yellowribbonbe.product.repository.custom.UserBenefitProductRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserBenefitProductRepository extends JpaRepository<UserBenefitProduct, Long>, UserBenefitProductRepositoryCustom {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/product/repository/custom/UserBenefitProductRepositoryCustom.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/product/repository/custom/UserBenefitProductRepositoryCustom.java
@@ -1,0 +1,9 @@
+package laughcandidate.yellowribbonbe.product.repository.custom;
+
+import laughcandidate.yellowribbonbe.product.entity.UserBenefitProduct;
+
+import java.util.List;
+
+public interface UserBenefitProductRepositoryCustom {
+    List<UserBenefitProduct> findActiveUserBenefitProductsByUserId(Long userId);
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/product/repository/custom/UserBenefitProductRepositoryCustomImpl.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/product/repository/custom/UserBenefitProductRepositoryCustomImpl.java
@@ -1,0 +1,30 @@
+package laughcandidate.yellowribbonbe.product.repository.custom;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import laughcandidate.yellowribbonbe.product.entity.UserBenefitProduct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static laughcandidate.yellowribbonbe.product.entity.QUserBenefitProduct.userBenefitProduct;
+import static laughcandidate.yellowribbonbe.product.entity.QProduct.product;
+
+@Repository
+@RequiredArgsConstructor
+public class UserBenefitProductRepositoryCustomImpl implements UserBenefitProductRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UserBenefitProduct> findActiveUserBenefitProductsByUserId(Long userId) {
+        return queryFactory
+                .selectFrom(userBenefitProduct)
+                .join(userBenefitProduct.product, product).fetchJoin()
+                .where(
+                    userBenefitProduct.user.id.eq(userId)
+                    .and(userBenefitProduct.isActive.isTrue())
+                )
+                .fetch();
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/product/service/ProductService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/product/service/ProductService.java
@@ -5,8 +5,10 @@ import laughcandidate.yellowribbonbe.global.exception.errorCode.ProductErrorCode
 import laughcandidate.yellowribbonbe.product.constants.ProductConstants;
 import laughcandidate.yellowribbonbe.product.dto.ProductDetailResponse;
 import laughcandidate.yellowribbonbe.product.dto.ProductListResponse;
+import laughcandidate.yellowribbonbe.product.dto.UserBenefitProductResponse;
 import laughcandidate.yellowribbonbe.product.entity.*;
 import laughcandidate.yellowribbonbe.product.repository.ProductRepository;
+import laughcandidate.yellowribbonbe.product.repository.UserBenefitProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +23,7 @@ import java.util.Optional;
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private final UserBenefitProductRepository userBenefitProductRepository;
 
     public List<ProductListResponse> getProducts(String category, Long badgeId) {
         ProductCategory productCategory = parseCategory(category);
@@ -111,5 +114,15 @@ public class ProductService {
         }
 
         return builder.build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserBenefitProductResponse> getMyBenefitProducts(Long userId) {
+        List<UserBenefitProduct> userBenefitProducts = 
+                userBenefitProductRepository.findActiveUserBenefitProductsByUserId(userId);
+        
+        return userBenefitProducts.stream()
+                .map(UserBenefitProductResponse::from)
+                .toList();
     }
 }


### PR DESCRIPTION
## 📄 PR 내용

유저가 이용 중인 혜택상품 리스트를 조회하는 API 구현


## 📝 수정 상세 내용

유저가 보유한 혜택 상품 리스트 조회

들어갈 항목:
- 상품명
- 상품 설명

## ✅ 체크리스트

- [x] 관련 엔티티 추가
- [x] is_active가 true인 혜택 상품 리스트 조회

