### PR TITLE
[FEAT] 사용자 보유 금융상품 리스트 조회

### DIFF
--- a/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/MyDataErrorCode.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/global/exception/errorCode/MyDataErrorCode.java
@@ -1,0 +1,21 @@
+package laughcandidate.yellowribbonbe.global.exception.errorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MyDataErrorCode implements ErrorCode {
+
+    // 400
+    INVALID_MYDATA_CATEGORY(HttpStatus.BAD_REQUEST, "MD-001", "잘못된 마이데이터 카테고리입니다: %s"),
+    
+    // 404
+    MYDATA_NOT_FOUND(HttpStatus.NOT_FOUND, "MD-002", "보유하신 금융상품이 없습니다."),
+    MYDATA_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "MD-003", "%s 상품을 보유하고 있지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/controller/MyDataController.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/controller/MyDataController.java
@@ -1,0 +1,58 @@
+package laughcandidate.yellowribbonbe.mydata.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import laughcandidate.yellowribbonbe.auth.service.CustomUserDetails;
+import laughcandidate.yellowribbonbe.global.exception.CustomException;
+import laughcandidate.yellowribbonbe.global.exception.errorCode.MyDataErrorCode;
+import laughcandidate.yellowribbonbe.global.response.ApiResponse;
+import laughcandidate.yellowribbonbe.mydata.dto.MyDataResponse;
+import laughcandidate.yellowribbonbe.mydata.service.MyDataService;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "마이데이터")
+@RestController
+@RequestMapping("/mydata")
+@RequiredArgsConstructor
+public class MyDataController {
+
+    private final MyDataService myDataService;
+
+    @GetMapping("/list")
+    @Operation(
+        summary = "사용자 보유 금융상품 리스트 조회 API",
+        description = "현재 로그인한 사용자가 보유한 금융상품 리스트를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<MyDataResponse>>> getMyFinancialProducts(
+            @RequestParam(required = false) String category,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        
+        List<MyDataResponse> myFinancialProducts;
+        
+        if (category == null || category.trim().isEmpty()) {
+            myFinancialProducts = myDataService.getAllMyFinancialProducts(customUserDetails.getUserId());
+        } else {
+            ProductCategory productCategory = parseCategory(category);
+            myFinancialProducts = myDataService.getMyFinancialProducts(customUserDetails.getUserId(), productCategory);
+        }
+        
+        return ResponseEntity.ok(ApiResponse.ok(myFinancialProducts));
+    }
+
+    private ProductCategory parseCategory(String category) {
+        if (category == null || category.trim().isEmpty()) {
+            return null;
+        }
+        
+        try {
+            return ProductCategory.valueOf(category.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(MyDataErrorCode.INVALID_MYDATA_CATEGORY, category);
+        }
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataDepositResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataDepositResponse.java
@@ -1,0 +1,48 @@
+package laughcandidate.yellowribbonbe.mydata.dto;
+
+import laughcandidate.yellowribbonbe.mydata.entity.MyDataDeposit;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public record MyDataDepositResponse(
+        String productName,
+        String category,
+        String interestRate,
+        String depositAmount,
+        String depositPeriod
+) implements MyDataResponse {
+
+    public static MyDataDepositResponse from(MyDataDeposit deposit) {
+        return new MyDataDepositResponse(
+                deposit.getProductName(),
+                deposit.getCategory().getDescription(),
+                String.format("%.2f%%", deposit.getInterestRate()),
+                formatToTenThousand(deposit.getAmount()),
+                formatDepositPeriod(deposit.getStartDate(), deposit.getMaturityDate())
+        );
+    }
+
+    private static String formatToTenThousand(BigDecimal amount) {
+        if (amount == null) return "0만원";
+        return String.format("%,d만원", amount.longValue() / 10000);
+    }
+
+    private static String formatDepositPeriod(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) return "";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        return String.format("%s ~ %s", startDate.format(formatter), endDate.format(formatter));
+    }
+
+    @Override
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public String getProductName() {
+        return productName;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataDepositResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataDepositResponse.java
@@ -1,5 +1,6 @@
 package laughcandidate.yellowribbonbe.mydata.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import laughcandidate.yellowribbonbe.mydata.entity.MyDataDeposit;
 import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
 
@@ -7,11 +8,17 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+@Schema(name = "MyDataDepositResponse: 나의 보유 예금 응답 DTO")
 public record MyDataDepositResponse(
+        @Schema(description = "예금 상품명", example = "KB기업자유예금통장")
         String productName,
+        @Schema(description = "상품 카테고리", example = "예금")
         String category,
+        @Schema(description = "적용 금리", example = "3.50%")
         String interestRate,
+        @Schema(description = "예치 금액", example = "1,500만원")
         String depositAmount,
+        @Schema(description = "예치 기간", example = "2024.01.15 ~ 2025.01.15")
         String depositPeriod
 ) implements MyDataResponse {
 

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataInsuranceResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataInsuranceResponse.java
@@ -1,16 +1,24 @@
 package laughcandidate.yellowribbonbe.mydata.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import laughcandidate.yellowribbonbe.mydata.entity.MyDataInsurance;
 import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
 
 import java.math.BigDecimal;
 
+@Schema(name = "MyDataInsuranceResponse: 나의 보유 보험 응답 DTO")
 public record MyDataInsuranceResponse(
+        @Schema(description = "보험 상품명", example = "삼성화재 소상공인 종합보험")
         String productName,
+        @Schema(description = "상품 카테고리", example = "보험")
         String category,
+        @Schema(description = "월 보험료", example = "50,000원")
         String monthlyPremium,
+        @Schema(description = "보장 종류", example = "소상공인종합보험")
         String coverageType,
+        @Schema(description = "보험 기간", example = "1년")
         String coveragePeriod,
+        @Schema(description = "보장 금액", example = "30,000만원")
         String coverageAmount
 ) implements MyDataResponse {
 

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataInsuranceResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataInsuranceResponse.java
@@ -1,0 +1,52 @@
+package laughcandidate.yellowribbonbe.mydata.dto;
+
+import laughcandidate.yellowribbonbe.mydata.entity.MyDataInsurance;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+
+import java.math.BigDecimal;
+
+public record MyDataInsuranceResponse(
+        String productName,
+        String category,
+        String monthlyPremium,
+        String coverageType,
+        String coveragePeriod,
+        String coverageAmount
+) implements MyDataResponse {
+
+    public static MyDataInsuranceResponse from(MyDataInsurance insurance) {
+        return new MyDataInsuranceResponse(
+                insurance.getProductName(),
+                insurance.getCategory().getDescription(),
+                formatPremium(insurance.getPremium()),
+                insurance.getCoverageType(),
+                formatCoveragePeriod(insurance.getInsTerm()),
+                formatToTenThousand(insurance.getCoverage())
+        );
+    }
+
+    private static String formatPremium(BigDecimal premium) {
+        if (premium == null) return "0원";
+        return String.format("%,d원", premium.longValue());
+    }
+
+    private static String formatCoveragePeriod(Integer insTerm) {
+        if (insTerm == null) return "";
+        return insTerm + "년";
+    }
+
+    private static String formatToTenThousand(BigDecimal amount) {
+        if (amount == null) return "0만원";
+        return String.format("%,d만원", amount.longValue() / 10000);
+    }
+
+    @Override
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public String getProductName() {
+        return productName;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataLoanResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataLoanResponse.java
@@ -1,5 +1,6 @@
 package laughcandidate.yellowribbonbe.mydata.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import laughcandidate.yellowribbonbe.mydata.entity.MyDataLoan;
 import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
 
@@ -9,14 +10,23 @@ import java.time.LocalDate;
 import java.time.Period;
 import java.time.format.DateTimeFormatter;
 
+@Schema(name = "MyDataLoanResponse: 나의 보유 대출 응답 DTO")
 public record MyDataLoanResponse(
+        @Schema(description = "대출 상품명", example = "KB소상공인 운영자금대출")
         String productName,
+        @Schema(description = "상품 카테고리", example = "대출")
         String category,
+        @Schema(description = "적용 금리", example = "5.20%")
         String interestRate,
+        @Schema(description = "상환 방식", example = "원리금균등분할상환")
         String repayMethod,
+        @Schema(description = "총 대출금", example = "5,000만원")
         String totalLoanAmount,
+        @Schema(description = "월 상환액", example = "85만원")
         String monthlyRepayment,
+        @Schema(description = "대출 잔액", example = "3,500만원")
         String remainingBalance,
+        @Schema(description = "대출 기간", example = "2023.06.15 ~ 2028.06.15")
         String loanPeriod
 ) implements MyDataResponse {
 

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataLoanResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataLoanResponse.java
@@ -1,0 +1,105 @@
+package laughcandidate.yellowribbonbe.mydata.dto;
+
+import laughcandidate.yellowribbonbe.mydata.entity.MyDataLoan;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
+
+public record MyDataLoanResponse(
+        String productName,
+        String category,
+        String interestRate,
+        String repayMethod,
+        String totalLoanAmount,
+        String monthlyRepayment,
+        String remainingBalance,
+        String loanPeriod
+) implements MyDataResponse {
+
+    public static MyDataLoanResponse from(MyDataLoan loan) {
+        return new MyDataLoanResponse(
+                loan.getProductName(),
+                loan.getCategory().getDescription(),
+                String.format("%.2f%%", loan.getInterestRate()),
+                loan.getRepayMethod(),
+                formatToTenThousand(loan.getPrincipal()),
+                calculateMonthlyRepayment(loan),
+                formatToTenThousand(loan.getRemainPrincipal()),
+                formatLoanPeriod(loan.getExecDate(), loan.getMaturityDate())
+        );
+    }
+
+    private static String formatToTenThousand(BigDecimal amount) {
+        if (amount == null) return "0만원";
+        return String.format("%,d만원", amount.longValue() / 10000);
+    }
+
+    private static String calculateMonthlyRepayment(MyDataLoan loan) {
+        // 대출잔액 × 월이율 ÷ (1 - (1+월이율)^(-남은기간))
+        // 월이율 = 금리 ÷ 12
+
+        BigDecimal remainingPrincipal = loan.getRemainPrincipal();
+        if (remainingPrincipal == null || remainingPrincipal.compareTo(BigDecimal.ZERO) == 0) {
+            return "0만원";
+        }
+
+
+        BigDecimal monthlyRate = loan.getInterestRate()
+                .divide(BigDecimal.valueOf(12), 10, RoundingMode.HALF_UP)
+                .divide(BigDecimal.valueOf(100), 10, RoundingMode.HALF_UP);
+
+        if (monthlyRate.compareTo(BigDecimal.ZERO) == 0) {
+            int remainingMonths = calculateRemainingMonths(loan.getExecDate(), loan.getMaturityDate());
+            if (remainingMonths <= 0) return "0만원";
+            BigDecimal monthlyAmount = remainingPrincipal.divide(BigDecimal.valueOf(remainingMonths), 0, RoundingMode.HALF_UP);
+            return formatToTenThousand(monthlyAmount);
+        }
+
+
+        int remainingMonths = calculateRemainingMonths(loan.getExecDate(), loan.getMaturityDate());
+        if (remainingMonths <= 0) return "0만원";
+
+        // (1 + 월이율)^(-남은기간)
+        BigDecimal onePlusRate = BigDecimal.ONE.add(monthlyRate);
+        BigDecimal powerResult = BigDecimal.ONE.divide(onePlusRate.pow(remainingMonths), 10, RoundingMode.HALF_UP);
+
+        // 1 - (1+월이율)^(-남은기간)
+        BigDecimal denominator = BigDecimal.ONE.subtract(powerResult);
+
+        // 대출잔액 × 월이율 ÷ (1 - (1+월이율)^(-남은기간))
+        BigDecimal monthlyPayment = remainingPrincipal.multiply(monthlyRate).divide(denominator, 0, RoundingMode.HALF_UP);
+
+        return formatToTenThousand(monthlyPayment);
+    }
+
+    private static int calculateRemainingMonths(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) return 24;
+        LocalDate now = LocalDate.now();
+
+        if (now.isAfter(endDate)) return 0;
+        if (now.isBefore(startDate)) now = startDate;
+
+        Period period = Period.between(now, endDate);
+        return period.getYears() * 12 + period.getMonths();
+    }
+
+    private static String formatLoanPeriod(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) return "";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        return String.format("%s ~ %s", startDate.format(formatter), endDate.format(formatter));
+    }
+
+    @Override
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public String getProductName() {
+        return productName;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataResponse.java
@@ -1,0 +1,6 @@
+package laughcandidate.yellowribbonbe.mydata.dto;
+
+public interface MyDataResponse {
+    String getProductName();
+    String getCategory();
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataSavingsResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataSavingsResponse.java
@@ -1,0 +1,83 @@
+package laughcandidate.yellowribbonbe.mydata.dto;
+
+import laughcandidate.yellowribbonbe.mydata.entity.MyDataSavings;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.Period;
+
+public record MyDataSavingsResponse(
+        String productName,
+        String category,
+        String interestRate,
+        String totalPaymentAmount,
+        String paymentPeriodMonths,
+        String monthlyPayment,
+        String maturityAmount
+) implements MyDataResponse {
+
+    public static MyDataSavingsResponse from(MyDataSavings savings) {
+        int periodInMonths = calculatePaymentPeriodInMonths(savings.getStartDate(), savings.getMaturityDate());
+        
+        return new MyDataSavingsResponse(
+                savings.getProductName(),
+                savings.getCategory().getDescription(),
+                String.format("%.2f%%", savings.getInterestRate()),
+                calculateTotalPaymentAmount(savings.getMonthlyPay(), periodInMonths),
+                periodInMonths + "개월",
+                formatToTenThousand(savings.getMonthlyPay()),
+                calculateMaturityAmount(savings.getMonthlyPay(), savings.getInterestRate(), periodInMonths)
+        );
+    }
+
+    private static int calculatePaymentPeriodInMonths(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) return 0;
+        Period period = Period.between(startDate, endDate);
+        return period.getYears() * 12 + period.getMonths();
+    }
+
+    private static String calculateTotalPaymentAmount(BigDecimal monthlyPay, int months) {
+        if (monthlyPay == null) return "0만원";
+        BigDecimal total = monthlyPay.multiply(BigDecimal.valueOf(months));
+        return formatToTenThousand(total);
+    }
+
+    private static String calculateMaturityAmount(BigDecimal monthlyPay, BigDecimal yearlyRate, int months) {
+        if (monthlyPay == null || yearlyRate == null || months == 0) return "0만원";
+        
+        // 월이율 = 연이율 ÷ 12
+        BigDecimal monthlyRate = yearlyRate.divide(BigDecimal.valueOf(12), 10, RoundingMode.HALF_UP)
+                                           .divide(BigDecimal.valueOf(100), 10, RoundingMode.HALF_UP);
+        
+        if (monthlyRate.compareTo(BigDecimal.ZERO) == 0) {
+            return calculateTotalPaymentAmount(monthlyPay, months);
+        }
+        
+        // 월납입액 × ( (1 + 월이율)^(납입기간) – 1 ) ÷ 월이율 × (1 + 월이율)
+        BigDecimal onePlusRate = BigDecimal.ONE.add(monthlyRate);
+        BigDecimal powerResult = onePlusRate.pow(months);
+        
+        BigDecimal numerator = powerResult.subtract(BigDecimal.ONE);
+        BigDecimal fraction = numerator.divide(monthlyRate, 10, RoundingMode.HALF_UP);
+        BigDecimal maturityAmount = monthlyPay.multiply(fraction).multiply(onePlusRate);
+        
+        return formatToTenThousand(maturityAmount);
+    }
+
+    private static String formatToTenThousand(BigDecimal amount) {
+        if (amount == null) return "0만원";
+        return String.format("%,d만원", amount.longValue() / 10000);
+    }
+
+    @Override
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public String getProductName() {
+        return productName;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataSavingsResponse.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/dto/MyDataSavingsResponse.java
@@ -1,5 +1,6 @@
 package laughcandidate.yellowribbonbe.mydata.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import laughcandidate.yellowribbonbe.mydata.entity.MyDataSavings;
 import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
 
@@ -8,13 +9,21 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.Period;
 
+@Schema(name = "MyDataSavingsResponse: 나의 보유 적금 응답 DTO")
 public record MyDataSavingsResponse(
+        @Schema(description = "적금 상품명", example = "KB사업자 세금적금")
         String productName,
+        @Schema(description = "상품 카테고리", example = "적금")
         String category,
+        @Schema(description = "적용 금리", example = "3.80%")
         String interestRate,
+        @Schema(description = "총 납입액", example = "1,200만원")
         String totalPaymentAmount,
+        @Schema(description = "납입 기간", example = "24개월")
         String paymentPeriodMonths,
+        @Schema(description = "월 납입액", example = "50만원")
         String monthlyPayment,
+        @Schema(description = "만기 예상 수령액", example = "1,280만원")
         String maturityAmount
 ) implements MyDataResponse {
 

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/entity/MyData.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/entity/MyData.java
@@ -1,0 +1,37 @@
+package laughcandidate.yellowribbonbe.mydata.entity;
+
+import jakarta.persistence.*;
+import laughcandidate.yellowribbonbe.global.entity.BaseEntity;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+import laughcandidate.yellowribbonbe.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "MYDATA")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "category")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class MyData extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "my_data_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "product_name")
+    private String productName;
+
+    protected MyData(User user, String productName) {
+        this.user = user;
+        this.productName = productName;
+    }
+
+    public abstract ProductCategory getCategory();
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/entity/MyDataDeposit.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/entity/MyDataDeposit.java
@@ -1,0 +1,60 @@
+package laughcandidate.yellowribbonbe.mydata.entity;
+
+import jakarta.persistence.*;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+import laughcandidate.yellowribbonbe.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "MYDATA_DEPOSIT")
+@DiscriminatorValue("DEPOSIT")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyDataDeposit extends MyData {
+
+    @Column(name = "interest_rate")
+    private BigDecimal interestRate;
+
+    @Column(name = "min_amount")
+    private BigDecimal minAmount;
+
+    @Column(name = "termination_rate")
+    private BigDecimal terminationRate;
+
+    @Column(name = "preferential")
+    private Integer preferential;
+
+    @Column(name = "amount")
+    private BigDecimal amount;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "maturity_date")
+    private LocalDate maturityDate;
+
+    @Builder
+    public MyDataDeposit(User user, String productName, BigDecimal interestRate, BigDecimal minAmount,
+                         BigDecimal terminationRate, Integer preferential, BigDecimal amount,
+                         LocalDate startDate, LocalDate maturityDate) {
+        super(user, productName);
+        this.interestRate = interestRate;
+        this.minAmount = minAmount;
+        this.terminationRate = terminationRate;
+        this.preferential = preferential;
+        this.amount = amount;
+        this.startDate = startDate;
+        this.maturityDate = maturityDate;
+    }
+
+    @Override
+    public ProductCategory getCategory() {
+        return ProductCategory.DEPOSIT;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/entity/MyDataInsurance.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/entity/MyDataInsurance.java
@@ -1,0 +1,60 @@
+package laughcandidate.yellowribbonbe.mydata.entity;
+
+import jakarta.persistence.*;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+import laughcandidate.yellowribbonbe.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "MYDATA_INSURANCE")
+@DiscriminatorValue("INSURANCE")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyDataInsurance extends MyData {
+
+    @Column(name = "ins_term")
+    private Integer insTerm;
+
+    @Column(name = "premium")
+    private BigDecimal premium;
+
+    @Column(name = "coverage_type")
+    private String coverageType;
+
+    @Column(name = "coverage")
+    private BigDecimal coverage;
+
+    @Column(name = "preferential")
+    private Integer preferential;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "maturity_date")
+    private LocalDate maturityDate;
+
+    @Builder
+    public MyDataInsurance(User user, String productName, Integer insTerm, BigDecimal premium,
+                           String coverageType, BigDecimal coverage, Integer preferential,
+                           LocalDate startDate, LocalDate maturityDate) {
+        super(user, productName);
+        this.insTerm = insTerm;
+        this.premium = premium;
+        this.coverageType = coverageType;
+        this.coverage = coverage;
+        this.preferential = preferential;
+        this.startDate = startDate;
+        this.maturityDate = maturityDate;
+    }
+
+    @Override
+    public ProductCategory getCategory() {
+        return ProductCategory.INSURANCE;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/entity/MyDataLoan.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/entity/MyDataLoan.java
@@ -1,0 +1,64 @@
+package laughcandidate.yellowribbonbe.mydata.entity;
+
+import jakarta.persistence.*;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+import laughcandidate.yellowribbonbe.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "MYDATA_LOAN")
+@DiscriminatorValue("LOAN")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyDataLoan extends MyData {
+
+    @Column(name = "interest_rate")
+    private BigDecimal interestRate;
+
+    @Column(name = "loan_limit")
+    private BigDecimal loanLimit;
+
+    @Column(name = "repay_method")
+    private String repayMethod;
+
+    @Column(name = "prepayment_fee_rate")
+    private BigDecimal prepaymentFeeRate;
+
+    @Column(name = "principal")
+    private BigDecimal principal;
+
+    @Column(name = "remain_principal")
+    private BigDecimal remainPrincipal;
+
+    @Column(name = "exec_date")
+    private LocalDate execDate;
+
+    @Column(name = "maturity_date")
+    private LocalDate maturityDate;
+
+    @Builder
+    public MyDataLoan(User user, String productName, BigDecimal interestRate, BigDecimal loanLimit,
+                      String repayMethod, BigDecimal prepaymentFeeRate, BigDecimal principal,
+                      BigDecimal remainPrincipal, LocalDate execDate, LocalDate maturityDate) {
+        super(user, productName);
+        this.interestRate = interestRate;
+        this.loanLimit = loanLimit;
+        this.repayMethod = repayMethod;
+        this.prepaymentFeeRate = prepaymentFeeRate;
+        this.principal = principal;
+        this.remainPrincipal = remainPrincipal;
+        this.execDate = execDate;
+        this.maturityDate = maturityDate;
+    }
+
+    @Override
+    public ProductCategory getCategory() {
+        return ProductCategory.LOAN;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/entity/MyDataSavings.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/entity/MyDataSavings.java
@@ -1,0 +1,64 @@
+package laughcandidate.yellowribbonbe.mydata.entity;
+
+import jakarta.persistence.*;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+import laughcandidate.yellowribbonbe.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "MYDATA_INSTALLMENT_SAVING")
+@DiscriminatorValue("SAVINGS")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyDataSavings extends MyData {
+
+    @Column(name = "interest_rate")
+    private BigDecimal interestRate;
+
+    @Column(name = "min_amount")
+    private BigDecimal minAmount;
+
+    @Column(name = "max_amount")
+    private BigDecimal maxAmount;
+
+    @Column(name = "termination_rate")
+    private BigDecimal terminationRate;
+
+    @Column(name = "preferential")
+    private Integer preferential;
+
+    @Column(name = "monthly_pay")
+    private BigDecimal monthlyPay;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "maturity_date")
+    private LocalDate maturityDate;
+
+    @Builder
+    public MyDataSavings(User user, String productName, BigDecimal interestRate, BigDecimal minAmount,
+                         BigDecimal maxAmount, BigDecimal terminationRate, Integer preferential,
+                         BigDecimal monthlyPay, LocalDate startDate, LocalDate maturityDate) {
+        super(user, productName);
+        this.interestRate = interestRate;
+        this.minAmount = minAmount;
+        this.maxAmount = maxAmount;
+        this.terminationRate = terminationRate;
+        this.preferential = preferential;
+        this.monthlyPay = monthlyPay;
+        this.startDate = startDate;
+        this.maturityDate = maturityDate;
+    }
+
+    @Override
+    public ProductCategory getCategory() {
+        return ProductCategory.SAVINGS;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/repository/MyDataRepository.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/repository/MyDataRepository.java
@@ -1,0 +1,10 @@
+package laughcandidate.yellowribbonbe.mydata.repository;
+
+import laughcandidate.yellowribbonbe.mydata.entity.MyData;
+import laughcandidate.yellowribbonbe.mydata.repository.custom.MyDataRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MyDataRepository extends JpaRepository<MyData, Long>, MyDataRepositoryCustom {
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/repository/custom/MyDataRepositoryCustom.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/repository/custom/MyDataRepositoryCustom.java
@@ -1,0 +1,11 @@
+package laughcandidate.yellowribbonbe.mydata.repository.custom;
+
+import laughcandidate.yellowribbonbe.mydata.entity.MyData;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+
+import java.util.List;
+
+public interface MyDataRepositoryCustom {
+    List<MyData> findByUserIdAndCategory(Long userId, ProductCategory category);
+    List<MyData> findByUserId(Long userId);
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/repository/custom/MyDataRepositoryCustomImpl.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/repository/custom/MyDataRepositoryCustomImpl.java
@@ -1,0 +1,90 @@
+package laughcandidate.yellowribbonbe.mydata.repository.custom;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import laughcandidate.yellowribbonbe.mydata.entity.*;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static laughcandidate.yellowribbonbe.mydata.entity.QMyDataLoan.myDataLoan;
+import static laughcandidate.yellowribbonbe.mydata.entity.QMyDataDeposit.myDataDeposit;
+import static laughcandidate.yellowribbonbe.mydata.entity.QMyDataSavings.myDataSavings;
+import static laughcandidate.yellowribbonbe.mydata.entity.QMyDataInsurance.myDataInsurance;
+
+@Repository
+@RequiredArgsConstructor
+public class MyDataRepositoryCustomImpl implements MyDataRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MyData> findByUserIdAndCategory(Long userId, ProductCategory category) {
+        return switch (category) {
+            case LOAN -> queryFactory
+                    .selectFrom(myDataLoan)
+                    .where(myDataLoan.user.id.eq(userId))
+                    .fetch()
+                    .stream()
+                    .map(MyData.class::cast)
+                    .toList();
+            
+            case DEPOSIT -> queryFactory
+                    .selectFrom(myDataDeposit)
+                    .where(myDataDeposit.user.id.eq(userId))
+                    .fetch()
+                    .stream()
+                    .map(MyData.class::cast)
+                    .toList();
+            
+            case SAVINGS -> queryFactory
+                    .selectFrom(myDataSavings)
+                    .where(myDataSavings.user.id.eq(userId))
+                    .fetch()
+                    .stream()
+                    .map(MyData.class::cast)
+                    .toList();
+            
+            case INSURANCE -> queryFactory
+                    .selectFrom(myDataInsurance)
+                    .where(myDataInsurance.user.id.eq(userId))
+                    .fetch()
+                    .stream()
+                    .map(MyData.class::cast)
+                    .toList();
+        };
+    }
+
+    @Override
+    public List<MyData> findByUserId(Long userId) {
+        List<MyData> result = new ArrayList<>();
+
+        List<MyDataLoan> loans = queryFactory
+                .selectFrom(myDataLoan)
+                .where(myDataLoan.user.id.eq(userId))
+                .fetch();
+        result.addAll(loans);
+
+        List<MyDataDeposit> deposits = queryFactory
+                .selectFrom(myDataDeposit)
+                .where(myDataDeposit.user.id.eq(userId))
+                .fetch();
+        result.addAll(deposits);
+
+        List<MyDataSavings> savings = queryFactory
+                .selectFrom(myDataSavings)
+                .where(myDataSavings.user.id.eq(userId))
+                .fetch();
+        result.addAll(savings);
+
+        List<MyDataInsurance> insurances = queryFactory
+                .selectFrom(myDataInsurance)
+                .where(myDataInsurance.user.id.eq(userId))
+                .fetch();
+        result.addAll(insurances);
+        
+        return result;
+    }
+}

--- a/src/main/java/laughcandidate/yellowribbonbe/mydata/service/MyDataService.java
+++ b/src/main/java/laughcandidate/yellowribbonbe/mydata/service/MyDataService.java
@@ -1,0 +1,55 @@
+package laughcandidate.yellowribbonbe.mydata.service;
+
+import laughcandidate.yellowribbonbe.global.exception.CustomException;
+import laughcandidate.yellowribbonbe.global.exception.errorCode.MyDataErrorCode;
+import laughcandidate.yellowribbonbe.mydata.dto.*;
+import laughcandidate.yellowribbonbe.mydata.entity.*;
+import laughcandidate.yellowribbonbe.mydata.repository.MyDataRepository;
+import laughcandidate.yellowribbonbe.product.entity.ProductCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyDataService {
+
+    private final MyDataRepository myDataRepository;
+
+    public List<MyDataResponse> getMyFinancialProducts(Long userId, ProductCategory category) {
+        List<MyData> myDataList = myDataRepository.findByUserIdAndCategory(userId, category);
+        
+        if (myDataList.isEmpty()) {
+            throw new CustomException(MyDataErrorCode.MYDATA_CATEGORY_NOT_FOUND, 
+                    category.getDescription());
+        }
+        
+        return myDataList.stream()
+                .map(this::convertToResponse)
+                .toList();
+    }
+
+    public List<MyDataResponse> getAllMyFinancialProducts(Long userId) {
+        List<MyData> myDataList = myDataRepository.findByUserId(userId);
+        
+        if (myDataList.isEmpty()) {
+            throw new CustomException(MyDataErrorCode.MYDATA_NOT_FOUND);
+        }
+        
+        return myDataList.stream()
+                .map(this::convertToResponse)
+                .toList();
+    }
+
+    private MyDataResponse convertToResponse(MyData myData) {
+        return switch (myData.getCategory()) {
+            case LOAN -> MyDataLoanResponse.from((MyDataLoan) myData);
+            case DEPOSIT -> MyDataDepositResponse.from((MyDataDeposit) myData);
+            case SAVINGS -> MyDataSavingsResponse.from((MyDataSavings) myData);
+            case INSURANCE -> MyDataInsuranceResponse.from((MyDataInsurance) myData);
+        };
+    }
+}


### PR DESCRIPTION
## 📄 PR 내용

사용자가 보유한 금융상품 리스트를 불러오는 API 구현


## 📝 수정 상세 내용

**불러올 항목**
대출: 상품명, 금리, 상환방식, 총 대출금, 월 상환액, 대출 잔액, 대출 기간(실행일자 ~ 만기일자)
예금: 상품명, 금리, 예치금액, 예치 기간(가입일자 ~ 만기일자)
적금: 상품명, 금리, 총 납입액(계산:월 납입액 * 납입기간), 납입 기간(개월, 계산:만기일자 - 가입일자), 월 납입액, 만기 수령액(계산: 복잡)
보험: 상품명, 월 납입 보험료, 보장 종류, 보장 기간, 보장 금액

## ✅ 체크리스트

- [x] 관련 엔티티 추가
- [x] 상품 유형별 항목 적용
